### PR TITLE
Add a configuration option to preserve the original Host header

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,7 +4,7 @@ Huginn Proxy is a reverse proxy focused on passive fingerprinting. The main goal
 
 Security features like TLS termination, mTLS, rate limiting, and IP filtering are included to meet production requirements. But this is not a general-purpose reverse proxy trying to compete with Nginx or HAProxy. Some common features you might expect are missing because they don't align with the fingerprinting use case.
 
-If you need advanced load balancing algorithms, circuit breakers, or complex routing rules, you should use a different proxy. This one does fingerprinting well and includes enough infrastructure features to run in production, but nothing more.
+If you need advanced load balancing algorithms, or complex routing rules, you should use a different proxy. This one does fingerprinting well and includes enough infrastructure features to run in production, but nothing more.
 
 ## Protocol Support
 
@@ -97,6 +97,16 @@ Limitation: Fingerprints are only extracted and forwarded, not validated or used
 Automatically adds X-Forwarded-For, X-Forwarded-Host, X-Forwarded-Port, and X-Forwarded-Proto. Client-provided values are overridden to prevent spoofing.
 
 Limitation: No configurable header names. No support for Forwarded header (RFC 7239).
+
+## Host Header Preservation
+
+**Configurable Host header forwarding**
+
+By default, the proxy replaces the Host header with the backend address. When preserve_host is enabled, the original Host header from the client is preserved and sent to the backend.
+
+This is useful for virtual hosting scenarios where the backend needs to know which domain was originally requested.
+
+Limitation: Global setting only, cannot be configured per-route.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ docker run -v /path/to/config.toml:/config.toml huginn-proxy /config.toml
 - **IP Filtering (ACL)** - Allowlist/denylist with CIDR notation support
 - **TLS Termination** - Server-side TLS with ALPN, certificate hot reload (single certificate per configuration)
 - **mTLS (Mutual TLS)** - Client certificate authentication for secure service-to-service communication
+- **Host Header Preservation** - Configurable forwarding of original Host header for virtual hosting
 - **Passive Fingerprinting** - Automatic TLS (JA4) and HTTP/2 (Akamai) fingerprint extraction
 - **X-Forwarded-* Headers** - Automatic injection of proxy forwarding headers
 - **High Performance** - Built on Tokio and Hyper

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,7 +8,6 @@
 
 ### Operational Features
 - [ ] Granular timeouts (read/write/TLS handshake)
-- [ ] Preserve Host header (configurable)
 - [ ] Backend health checks (active polling)
 - [ ] Connection pooling for backends
 

--- a/huginn-proxy-lib/src/config/types.rs
+++ b/huginn-proxy-lib/src/config/types.rs
@@ -327,6 +327,12 @@ pub struct Config {
     /// If no routes match, requests return 404
     #[serde(default)]
     pub routes: Vec<Route>,
+    /// Preserve the original Host header from clients when forwarding to backends
+    /// When true: Backend receives the original Host header (useful for virtual hosting)
+    /// When false: Backend receives the backend address as Host header (default)
+    /// Default: false
+    #[serde(default)]
+    pub preserve_host: bool,
     /// TLS termination configuration (optional)
     /// If not provided, proxy operates in plain HTTP mode
     /// Default: None

--- a/huginn-proxy-lib/src/proxy/handler/request.rs
+++ b/huginn-proxy-lib/src/proxy/handler/request.rs
@@ -49,6 +49,7 @@ pub async fn handle_proxy_request(
     metrics: Option<Arc<Metrics>>,
     peer: std::net::SocketAddr,
     is_https: bool,
+    preserve_host: bool,
 ) -> HttpResult<hyper::Response<RespBody>> {
     let start = Instant::now();
     let method = req.method().to_string();
@@ -136,6 +137,7 @@ pub async fn handle_proxy_request(
             replace_path: route_match.replace_path,
             security_headers: Some(&security.headers),
             is_https,
+            preserve_host,
         },
     )
     .await;

--- a/huginn-proxy-lib/src/proxy/server.rs
+++ b/huginn-proxy-lib/src/proxy/server.rs
@@ -123,6 +123,7 @@ pub async fn run(config: Arc<Config>, metrics: Option<Arc<Metrics>>) -> Result<(
                 let keep_alive_config = config.timeout.keep_alive.clone();
                 let security = security_context.clone();
                 let metrics_clone = metrics.clone();
+                let preserve_host = config.preserve_host;
 
                 let metrics_for_connection = metrics_clone.clone();
                 tokio::spawn(async move {
@@ -141,6 +142,7 @@ pub async fn run(config: Arc<Config>, metrics: Option<Arc<Metrics>>) -> Result<(
                                 security: security.clone(),
                                 metrics: metrics_for_connection,
                                 builder: builder_clone,
+                                preserve_host,
                             },
                         )
                         .await;
@@ -155,6 +157,7 @@ pub async fn run(config: Arc<Config>, metrics: Option<Arc<Metrics>>) -> Result<(
                                 security: security.clone(),
                                 metrics: metrics_for_connection,
                                 builder: builder_clone,
+                                preserve_host,
                             },
                         )
                         .await;

--- a/huginn-proxy-lib/src/proxy/transport/plain.rs
+++ b/huginn-proxy-lib/src/proxy/transport/plain.rs
@@ -19,6 +19,7 @@ pub struct PlainConnectionConfig {
     pub security: crate::proxy::SecurityContext,
     pub metrics: Option<Arc<Metrics>>,
     pub builder: ConnBuilder<TokioExecutor>,
+    pub preserve_host: bool,
 }
 
 /// Handle a plain HTTP connection
@@ -41,6 +42,7 @@ pub async fn handle_plain_connection(
         let security = security.clone();
 
         async move {
+            let preserve_host = config.preserve_host;
             let metrics_for_match = metrics.clone();
             let http_result = crate::proxy::handler::request::handle_proxy_request(
                 req,
@@ -53,6 +55,7 @@ pub async fn handle_plain_connection(
                 metrics,
                 peer,
                 false, // is_https = false for plain HTTP connections
+                preserve_host,
             )
             .await;
 

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -27,6 +27,7 @@ pub struct TlsConnectionConfig {
     pub security: crate::proxy::SecurityContext,
     pub metrics: Option<Arc<Metrics>>,
     pub builder: ConnBuilder<TokioExecutor>,
+    pub preserve_host: bool,
 }
 
 /// Handle a TLS connection
@@ -107,6 +108,7 @@ pub async fn handle_tls_connection(
 
                             async move {
                                 let metrics_for_match = metrics.clone();
+                                let preserve_host = config.preserve_host;
                                 let http_result =
                                     crate::proxy::handler::request::handle_proxy_request(
                                         req,
@@ -119,6 +121,7 @@ pub async fn handle_tls_connection(
                                         metrics,
                                         peer,
                                         true,
+                                        preserve_host,
                                     )
                                     .await;
 
@@ -190,6 +193,7 @@ pub async fn handle_tls_connection(
                             let security = security.clone();
 
                             async move {
+                                let preserve_host = config.preserve_host;
                                 let metrics_for_match = metrics.clone();
                                 let http_result =
                                     crate::proxy::handler::request::handle_proxy_request(
@@ -203,6 +207,7 @@ pub async fn handle_tls_connection(
                                         metrics,
                                         peer,
                                         true,
+                                        preserve_host,
                                     )
                                     .await;
 

--- a/huginn-proxy-lib/tests/config/types.rs
+++ b/huginn-proxy-lib/tests/config/types.rs
@@ -125,3 +125,42 @@ required = { ca_cert_path = "/config/certs/client-ca.crt" }
     }
     Ok(())
 }
+
+#[test]
+fn test_preserve_host_default_is_false() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let toml = r#"
+listen = "0.0.0.0:7000"
+backends = [{ address = "backend:9000" }]
+"#;
+
+    let config: Config = toml::from_str(toml)?;
+    assert!(!config.preserve_host);
+    Ok(())
+}
+
+#[test]
+fn test_preserve_host_enabled() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let toml = r#"
+listen = "0.0.0.0:7000"
+backends = [{ address = "backend:9000" }]
+preserve_host = true
+"#;
+
+    let config: Config = toml::from_str(toml)?;
+    assert!(config.preserve_host);
+    Ok(())
+}
+
+#[test]
+fn test_preserve_host_disabled_explicitly() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+{
+    let toml = r#"
+listen = "0.0.0.0:7000"
+backends = [{ address = "backend:9000" }]
+preserve_host = false
+"#;
+
+    let config: Config = toml::from_str(toml)?;
+    assert!(!config.preserve_host);
+    Ok(())
+}

--- a/huginn-proxy-lib/tests/integration.rs
+++ b/huginn-proxy-lib/tests/integration.rs
@@ -12,6 +12,7 @@ fn create_test_config(listen: &str, backends: Vec<Backend>) -> Config {
             .unwrap_or_else(|_| panic!("Invalid listen address: {listen}")),
         backends,
         routes: vec![],
+        preserve_host: false,
         tls: None,
         fingerprint: FingerprintConfig {
             tls_enabled: true,


### PR DESCRIPTION
**Description:**
Add a configuration option to preserve the original Host header from the client request when forwarding to backends, instead of using the backend's hostname.