### PR TITLE
Enable ebpf metrics in compose

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -11,7 +11,7 @@ Two benchmark suites with different scopes:
 
 ## Environment
 
-All **sample** and **baseline** tables in this document share one setup: **Intel i7-1165G7** (4 cores / 8 threads), **32 GB RAM**, Linux, `cargo bench` **release** on `localhost`. Numbers are **indicative** — expect **±5–15%** variance between runs (thermals, scheduling).
+**Load tests** (oha, k6) target a **minimal Docker Compose** stack: **one** proxy, **one** eBPF agent, and **one** backend — a simplified layout on purpose; **more replicas and stronger hardware** usually improve throughput and latency. **Criterion** runs (`cargo bench`, release) execute on the host without Compose. All figures are **indicative** (~**±5–15%** between runs).
 
 ---
 
@@ -242,10 +242,4 @@ For JA4-only (HTTP/1.1, no Akamai check): `K6_NO_HTTP2=true k6 run --insecure-sk
 
 ### CPU / memory (container)
 
-k6 doesn’t show cgroup usage — use `docker stats` on the `proxy` container, or:
-
-```bash
-./benches/load/k6/run-with-docker-stats.sh k6 run --insecure-skip-tls-verify benches/load/k6/fingerprints.js
-```
-
-Writes `benches/load/k6/last-docker-stats.tsv`. App counters: `http://127.0.0.1:9090/metrics`.
+k6 doesn’t show cgroup usage — use `docker stats` on the `proxy` container while the test runs. App counters: `http://127.0.0.1:9090/metrics`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -144,7 +144,7 @@ curl -6 http://localhost:9090/metrics | grep huginn_proxy
 | eBPF Agent | `http://127.0.0.1:9091/live` | Liveness |
 | eBPF Agent | `http://127.0.0.1:9091/metrics` | Prometheus metrics |
 
-In the example compose, agent endpoints are exposed via the proxy service (`9091:9091`). From the host use e.g. `curl http://127.0.0.1:9091/metrics`. If your compose does not publish 9091, use `docker exec` into the proxy container (the image has no curl; run `curl` from the host instead).
+eBPF compose examples map agent HTTP on the proxy service (`9091:9091`).
 
 ---
 

--- a/examples/docker-compose.release-ebpf.yml
+++ b/examples/docker-compose.release-ebpf.yml
@@ -21,7 +21,7 @@ services:
       - HUGINN_EBPF_PIN_PATH=/sys/fs/bpf/huginn
       - HUGINN_EBPF_SYN_MAP_MAX_ENTRIES=8192
       - HUGINN_EBPF_XDP_MODE=skb
-      - HUGINN_EBPF_METRICS_ADDR=127.0.0.1
+      - HUGINN_EBPF_METRICS_ADDR=0.0.0.0
       - HUGINN_EBPF_METRICS_PORT=9091
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://127.0.0.1:9091/ready || exit 1"]

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - HUGINN_EBPF_PIN_PATH=/sys/fs/bpf/huginn
       - HUGINN_EBPF_SYN_MAP_MAX_ENTRIES=8192
       - HUGINN_EBPF_XDP_MODE=skb
-      - HUGINN_EBPF_METRICS_ADDR=127.0.0.1
+      - HUGINN_EBPF_METRICS_ADDR=0.0.0.0
       - HUGINN_EBPF_METRICS_PORT=9091
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://127.0.0.1:9091/ready || exit 1"]


### PR DESCRIPTION
The idea is just enable eBFP metrics in docker compose used as example