### PR TITLE
Hot certificate reload memory grows

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ extracting TLS (JA4), HTTP/2 (Akamai), and TCP SYN (p0f-style) fingerprints and 
 fingerprinting is implemented via an XDP eBPF program using [Aya](https://aya-rs.dev). Fingerprinting libraries are
 provided by [Huginn Net](https://github.com/biandratti/huginn-net).
 
-Inspired by production-grade proxies
-like [Pingora](https://github.com/cloudflare/pingora), [Sozu](https://github.com/sozu-proxy/sozu),
+Inspired by production-grade proxies like [Pingora](https://github.com/cloudflare/pingora)
 and [rust-rpxy](https://github.com/junkurihara/rust-rpxy).
 
 ## Quick Start

--- a/benches/bench_proxy.rs
+++ b/benches/bench_proxy.rs
@@ -63,7 +63,7 @@ const EXPECTED_JA4: &str = "t13i1010h2_61a7ad8aa9b6_3a8073edd8ef";
 const EXPECTED_AKAMAI: &str = "2:0;4:2097152;5:16384;6:16384|5177345|0|m,s,a,p";
 
 // ---------------------------------------------------------------------------
-// Rustls crypto provider — must be installed once per process before any
+// Rustls crypto provider must be installed once per process before any
 // TLS handshake. Criterion runs multiple benchmark fns in the same process.
 // ---------------------------------------------------------------------------
 fn ensure_crypto_provider() {

--- a/huginn-ebpf-agent/src/main.rs
+++ b/huginn-ebpf-agent/src/main.rs
@@ -81,12 +81,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         dst_ip_v6 = %cfg.dst_ip_v6,
         dst_port = %cfg.dst_port,
         xdp_mode = xdp_mode_str,
-        "eBPF agent ready — waiting for SIGTERM"
+        "eBPF agent ready, waiting for SIGTERM"
     );
 
     wait_for_shutdown_signal().await?;
 
-    tracing::info!("Shutting down — unpinning maps and detaching XDP");
+    tracing::info!("Shutting down, unpinning maps and detaching XDP");
     EbpfProbe::unpin_maps(&cfg.pin_path);
     drop(probe);
 

--- a/huginn-ebpf-common/src/lib.rs
+++ b/huginn-ebpf-common/src/lib.rs
@@ -27,7 +27,7 @@ pub fn make_key_v4(src_ip: u32, src_port: u16) -> u64 {
 /// followed by 2 bytes of port in native-endian order, which on a LE CPU recovers
 /// the original big-endian wire bytes stored in `tcp->source`.
 ///
-/// `src_addr` is `ip6->saddr` as a byte array — no endianness conversion needed.
+/// `src_addr` is `ip6->saddr` as a byte array, no endianness conversion needed.
 /// `src_port` is `tcp->source` as a u16 NBO-as-NE value (raw LE read of BE bytes).
 ///
 /// Userspace (`huginn-ebpf`) uses `make_bpf_key_v6` which reconstructs the same bytes

--- a/huginn-ebpf/src/probe.rs
+++ b/huginn-ebpf/src/probe.rs
@@ -146,7 +146,7 @@ impl EbpfProbe {
     ///
     /// `syn_map_max_entries` must match the value the agent used when loading the program
     /// (e.g. `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES`); it is used for stale entry detection.
-    /// This constructor does not load or attach any XDP program — the agent owns that lifecycle.
+    /// This constructor does not load or attach any XDP program, the agent owns that lifecycle.
     pub fn from_pinned(base_path: &str, syn_map_max_entries: u32) -> Result<Self, EbpfError> {
         let syn_map_path = pin::syn_map_v4_path(base_path);
         let syn_map_v6_path = pin::syn_map_v6_path(base_path);
@@ -305,7 +305,7 @@ impl EbpfProbe {
             })?;
 
         // BPF_OBJ_GET checks inode permissions (MAY_READ | MAY_WRITE).
-        // Pin files are created as 0600 root:root — make them accessible
+        // Pin files are created as 0600 root:root, make them accessible
         // to the non-root proxy process.
         let open_mode = std::fs::Permissions::from_mode(0o666);
         let _ = std::fs::set_permissions(&syn_path_v4, open_mode.clone());

--- a/huginn-ebpf/tests/pin.rs
+++ b/huginn-ebpf/tests/pin.rs
@@ -1,6 +1,3 @@
-//! T2.4 — Tests for pin path construction.
-//! Ensures path helpers produce the expected filenames so agent and proxy agree on map locations.
-
 use std::path::Path;
 
 use huginn_ebpf::pin;

--- a/huginn-proxy-lib/src/backend/health_check/counter.rs
+++ b/huginn-proxy-lib/src/backend/health_check/counter.rs
@@ -29,7 +29,7 @@ impl ConsecutiveCounter {
     /// Create a new counter starting in the healthy state ("optimistic boot",
     /// matching [`crate::backend::health_check::UpstreamHealth::new`]).
     ///
-    /// Both thresholds are clamped to a minimum of 1 — passing 0 would never
+    /// Both thresholds are clamped to a minimum of 1, passing 0 would never
     /// trigger a transition, which is almost certainly a misconfiguration.
     pub fn new(unhealthy_threshold: u32, healthy_threshold: u32) -> Self {
         Self {
@@ -43,7 +43,7 @@ impl ConsecutiveCounter {
 
     /// Record a check result.
     ///
-    /// Returns `Some(new_state)` only when a state transition occurred —
+    /// Returns `Some(new_state)` only when a state transition occurred
     /// callers use this to update the shared [`crate::backend::health_check::UpstreamHealth`]
     /// flag and emit a metric / log line. Returns `None` for the common case
     /// where the streak grew but no threshold was crossed.

--- a/huginn-proxy-lib/src/backend/health_check/health.rs
+++ b/huginn-proxy-lib/src/backend/health_check/health.rs
@@ -13,7 +13,7 @@
 //! for health checks: a stale read for a few microseconds during a transition
 //! does not change the observable behaviour (one extra request to a backend
 //! about to be marked unhealthy, or one fewer request to a backend about to
-//! recover — both are inside the noise floor of the probe interval).
+//! recover both are inside the noise floor of the probe interval).
 
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/huginn-proxy-lib/src/backend/health_check/registry.rs
+++ b/huginn-proxy-lib/src/backend/health_check/registry.rs
@@ -15,7 +15,7 @@
 //!
 //! Backends without a `[backends.health_check]` configuration are **not**
 //! inserted into the registry. [`HealthRegistry::is_healthy`] returns `true`
-//! for any unknown address — health checks are per-backend opt-in; traffic is
+//! for any unknown address, health checks are per-backend opt-in; traffic is
 //! not gated until a backend registers a probe.
 
 use super::health::UpstreamHealth;

--- a/huginn-proxy-lib/src/backend/upstream_gateway.rs
+++ b/huginn-proxy-lib/src/backend/upstream_gateway.rs
@@ -5,7 +5,7 @@ use super::{BackendSelector, HealthRegistry};
 /// Combines selection and health-gate into a single forwarding context.
 ///
 /// [`BackendSelector`] (round-robin algorithm) and the [`HealthRegistry`]
-/// (per-backend health state). Cheap to clone — both fields are `Arc`.
+/// (per-backend health state). Cheap to clone both fields are `Arc`.
 #[derive(Clone)]
 pub struct UpstreamGateway {
     pub health: Arc<HealthRegistry>,

--- a/huginn-proxy-lib/src/config/dynamic/security.rs
+++ b/huginn-proxy-lib/src/config/dynamic/security.rs
@@ -6,7 +6,7 @@ use super::headers::CustomHeader;
 /// Security configuration (used for TOML deserialization via Config)
 #[derive(Debug, Deserialize, Clone)]
 pub struct SecurityConfig {
-    /// Maximum number of concurrent connections allowed (static — requires restart to change)
+    /// Maximum number of concurrent connections allowed (static requires restart to change)
     #[serde(default = "default_max_connections")]
     pub max_connections: usize,
     /// Security headers configuration

--- a/huginn-proxy-lib/src/config/parser/mod.rs
+++ b/huginn-proxy-lib/src/config/parser/mod.rs
@@ -42,9 +42,9 @@ pub trait ConfigParser: Send + Sync {
 /// [`ConfigFormat::parser`] to obtain the matching [`ConfigParser`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigFormat {
-    /// TOML — used for `.toml` files.
+    /// TOML used for `.toml` files.
     Toml,
-    /// YAML — used for `.yaml` and `.yml` files.
+    /// YAML used for `.yaml` and `.yml` files.
     Yaml,
 }
 

--- a/huginn-proxy-lib/src/config/root.rs
+++ b/huginn-proxy-lib/src/config/root.rs
@@ -13,7 +13,7 @@ use super::startup::timeout::TimeoutConfig;
 use super::startup::tls::TlsConfig;
 use super::startup::StaticConfig;
 
-/// Main configuration structure — the TOML deserialization target.
+/// Main configuration structure, the TOML deserialization target.
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     /// Listener configuration (addresses and socket options)

--- a/huginn-proxy-lib/src/config/startup/listen.rs
+++ b/huginn-proxy-lib/src/config/startup/listen.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use std::net::SocketAddr;
 
-/// Listener configuration — addresses and kernel socket options.
+/// Listener configuration, addresses and kernel socket options.
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 pub struct ListenConfig {
     /// Addresses and ports to listen on. One or more entries, one per IP family.
@@ -18,7 +18,7 @@ pub struct ListenConfig {
     /// ["0.0.0.0:7000", "[::]:7000"]
     /// ```
     pub addrs: Vec<SocketAddr>,
-    /// `listen(2)` backlog — length of the pending-connection queue per listener socket.
+    /// `listen(2)` backlog, length of the pending-connection queue per listener socket.
     /// Raise this under high connection rates to avoid the kernel silently dropping SYNs before
     /// `accept(2)` is called. The kernel clamps the value to `net.core.somaxconn`.
     /// Passed directly to `listen(2)`. Default: 4096 (matches modern Linux SOMAXCONN)

--- a/huginn-proxy-lib/src/config/startup/mod.rs
+++ b/huginn-proxy-lib/src/config/startup/mod.rs
@@ -10,7 +10,7 @@ pub use telemetry::{LoggingConfig, TelemetryConfig};
 pub use timeout::{KeepAliveConfig, TimeoutConfig};
 pub use tls::{ClientAuth, SessionResumptionConfig, TlsConfig, TlsOptions, TlsVersion};
 
-/// Static configuration — read once at startup, requires restart to change.
+/// Static configuration read once at startup, requires restart to change.
 ///
 /// Contains all fields that require OS-level resources (socket binding, TLS
 /// stack initialization, logging setup) or are too fundamental to change

--- a/huginn-proxy-lib/src/config/watcher.rs
+++ b/huginn-proxy-lib/src/config/watcher.rs
@@ -16,9 +16,9 @@ use crate::error::ProxyError;
 /// ## Watch strategy
 ///
 /// Two watches are registered:
-/// - **Parent directory** — catches atomic saves (editor writes a temp file and
+/// - **Parent directory** catches atomic saves (editor writes a temp file and
 ///   renames it into place, generating a `Create`/`Modify` event in the dir).
-/// - **Config file directly** — catches in-place writes through single-file bind
+/// - **Config file directly** catches in-place writes through single-file bind
 ///   mounts (Docker, Kubernetes `hostPath`/`ConfigMap` subPath, Podman, etc.):
 ///   the container sees the host inode directly, but the parent directory is an
 ///   overlayfs layer that does not propagate inotify events to the mounted file.
@@ -63,7 +63,7 @@ pub fn spawn_config_watcher(
     info!(
         path = %config_path.display(),
         debounce_secs = watch_delay_secs,
-        "Config watcher started — watching for file changes"
+        "Config watcher started, watching for file changes"
     );
 
     tokio::spawn(async move {
@@ -74,7 +74,7 @@ pub fn spawn_config_watcher(
         loop {
             tokio::select! {
                 _ = event_rx.recv() => {
-                    info!(path = %config_path.display(), debounce_secs = watch_delay_secs, "Config file change detected — reload scheduled");
+                    info!(path = %config_path.display(), debounce_secs = watch_delay_secs, "Config file change detected, reload scheduled");
                     reload_deadline = Instant::now().checked_add(debounce_duration)
                         .or_else(|| Instant::now().checked_add(Duration::from_secs(60)));
                 }

--- a/huginn-proxy-lib/src/proxy/connection/guards.rs
+++ b/huginn-proxy-lib/src/proxy/connection/guards.rs
@@ -34,7 +34,7 @@ impl Drop for ConnectionGuard {
 }
 
 /// Guard to decrement TLS connection metrics counter when dropped.
-/// Does NOT touch the main `active_connections` counter — that is handled by `ConnectionGuard`.
+/// Does NOT touch the main `active_connections` counter that is handled by `ConnectionGuard`.
 pub struct TlsConnectionGuard {
     tls_active: Option<opentelemetry::metrics::UpDownCounter<i64>>,
 }

--- a/huginn-proxy-lib/src/proxy/reload.rs
+++ b/huginn-proxy-lib/src/proxy/reload.rs
@@ -52,7 +52,7 @@ pub async fn try_reload(
     let new_config = match load_from_path(config_path) {
         Ok(c) => c,
         Err(e) => {
-            error!(error = %e, "Config reload failed: parse error — keeping current config");
+            error!(error = %e, "Config reload failed: parse error, keeping current config");
             metrics.record_reload_error();
             return;
         }
@@ -60,7 +60,7 @@ pub async fn try_reload(
 
     // cross-reference validation
     if let Err(e) = new_config.validate_cross_refs() {
-        error!(error = %e, "Config reload failed: validation error — keeping current config");
+        error!(error = %e, "Config reload failed: validation error, keeping current config");
         metrics.record_reload_error();
         return;
     }
@@ -71,7 +71,7 @@ pub async fn try_reload(
     if new_static != *static_cfg {
         error!(
             "Config reload: static sections changed (listen, tls, fingerprint, timeout, …) \
-             — these changes have NO effect until restart"
+             these changes have NO effect until restart"
         );
     }
 
@@ -90,7 +90,7 @@ pub async fn try_reload(
             None
         };
         rate_limiter.store(Arc::new(new_mgr));
-        info!("Rate-limit config changed — counters reset");
+        info!("Rate-limit config changed counters reset");
     }
 
     // Refresh the connection pool when backends are removed or pool config changes.
@@ -226,7 +226,7 @@ fn drain_removed_backends(
 
 /// Compute a fast FNV-1a hash of a `DynamicConfig` via its `Debug` representation.
 ///
-/// Used exclusively for the `huginn_config_hash` Prometheus gauge — must be
+/// Used exclusively for the `huginn_config_hash` Prometheus gauge must be
 /// deterministic within a process run and change whenever the config changes.
 /// Cross-run or cross-version stability is not required.
 fn fnv1a_hash(dynamic: &DynamicConfig) -> u64 {

--- a/huginn-proxy-lib/src/proxy/server.rs
+++ b/huginn-proxy-lib/src/proxy/server.rs
@@ -88,7 +88,7 @@ pub async fn run(
                 spawn_config_watcher(config_path.clone(), reload_tx, watch_opts.watch_delay_secs)?;
             }
             None => {
-                warn!("HUGINN_WATCH=true but no config path provided — hot-reload disabled");
+                warn!("HUGINN_WATCH=true but no config path provided hot-reload disabled");
             }
         }
     } else {
@@ -153,7 +153,7 @@ pub async fn run(
                 if watch_opts.config_path.is_some() {
                     let _ = sighup_tx.send(());
                 } else {
-                    warn!("SIGHUP received but no config path configured — reload skipped");
+                    warn!("SIGHUP received but no config path configured reload skipped");
                 }
             }
             Some(_) = reload_rx.recv() => {

--- a/huginn-proxy-lib/src/telemetry/metrics.rs
+++ b/huginn-proxy-lib/src/telemetry/metrics.rs
@@ -120,11 +120,11 @@ pub struct Metrics {
     pub health_check_gate_rejects_total: Counter<u64>,
 
     // Config reload metrics
-    /// `huginn_config_reload_total{result="success|error"}` — total reload attempts.
+    /// `huginn_config_reload_total{result="success|error"}` total reload attempts.
     pub config_reload_total: Counter<u64>,
     /// Unix timestamp (seconds) of the last successful reload.
     pub config_last_reload_timestamp_seconds: Gauge<f64>,
-    /// FNV-1a hash of the active `DynamicConfig` — changes on every successful reload.
+    /// FNV-1a hash of the active `DynamicConfig` changes on every successful reload.
     pub config_hash: Gauge<u64>,
 }
 
@@ -625,8 +625,8 @@ impl Metrics {
     /// Record a rejected incoming connection.
     ///
     /// `reason` is one of:
-    /// - `"limit_exceeded"` — active connection count hit `max_connections`
-    /// - `"shutdown"`       — proxy is shutting down
+    /// - `"limit_exceeded"` active connection count hit `max_connections`
+    /// - `"shutdown"`       proxy is shutting down
     pub fn record_connection_rejected(&self, reason: &'static str) {
         self.connections_rejected_total
             .add(1, &[KeyValue::new(labels::REASON, reason)]);

--- a/huginn-proxy-lib/src/tls/reloader.rs
+++ b/huginn-proxy-lib/src/tls/reloader.rs
@@ -69,12 +69,12 @@ pub async fn read_certs_and_keys(
         ProxyError::Tls(format!("Unable to load the certificates [{}]: {e}", cert_path.display()))
     })?;
 
-    // Parse certificates and convert to 'static lifetime by leaking the bytes (the bytes will live for the lifetime of the program)
-    let cert_bytes_leaked: &'static [u8] = Box::leak(cert_bytes.into_boxed_slice());
-    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(cert_bytes_leaked)
-        .collect::<std::result::Result<Vec<CertificateDer<'static>>, rustls_pki_types::pem::Error>>(
-        )
-        .map_err(|e| ProxyError::Tls(format!("Unable to parse the certificates: {e}")))?;
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&cert_bytes)
+        .collect::<Result<Vec<_>, rustls_pki_types::pem::Error>>()
+        .map_err(|e| ProxyError::Tls(format!("Unable to parse the certificates: {e}")))?
+        .into_iter()
+        .map(|c| c.into_owned())
+        .collect();
 
     if certs.is_empty() {
         return Err(ProxyError::Tls("No certificates found".to_string()));
@@ -87,11 +87,12 @@ pub async fn read_certs_and_keys(
         ))
     })?;
 
-    // Parse keys and convert to 'static lifetime by leaking the bytes (the bytes will live for the lifetime of the program)
-    let key_bytes_leaked: &'static [u8] = Box::leak(key_bytes.into_boxed_slice());
-    let mut keys: Vec<PrivateKeyDer<'static>> = PrivateKeyDer::pem_slice_iter(key_bytes_leaked)
-        .collect::<std::result::Result<Vec<PrivateKeyDer<'static>>, rustls_pki_types::pem::Error>>()
-        .map_err(|e| ProxyError::Tls(format!("Unable to parse the private keys: {e}")))?;
+    let mut keys: Vec<PrivateKeyDer<'static>> = PrivateKeyDer::pem_slice_iter(&key_bytes)
+        .collect::<Result<Vec<_>, rustls_pki_types::pem::Error>>()
+        .map_err(|e| ProxyError::Tls(format!("Unable to parse the private keys: {e}")))?
+        .into_iter()
+        .map(|k| k.clone_key())
+        .collect();
 
     let key = keys.pop().ok_or_else(|| {
         ProxyError::Tls(

--- a/huginn-proxy-lib/src/tls/reloader.rs
+++ b/huginn-proxy-lib/src/tls/reloader.rs
@@ -103,7 +103,7 @@ pub async fn read_certs_and_keys(
     Ok(ServerCertsKeys { certs, key })
 }
 
-/// Load certificates once and return a static receiver — no filesystem watching.
+/// Load certificates once and return a static receiver, no filesystem watching.
 async fn load_certs_static(
     cert_path: &Path,
     key_path: &Path,

--- a/huginn-proxy-lib/tests/backend/health_check/supervisor.rs
+++ b/huginn-proxy-lib/tests/backend/health_check/supervisor.rs
@@ -25,7 +25,7 @@ async fn supervisor_marks_unhealthy_on_unreachable_port() {
     let sup = HealthCheckSupervisor::new(registry.clone());
     let backend = tcp_backend("127.0.0.1:1", 1, 2);
     sup.reconcile(std::slice::from_ref(&backend), &Metrics::new_noop(), &Handle::current());
-    // First tick is immediate, then one per second — allow time for 2 failed probes.
+    // First tick is immediate, then one per second allow time for 2 failed probes.
     tokio::time::sleep(Duration::from_secs(3)).await;
     assert!(
         !registry.is_healthy("127.0.0.1:1"),

--- a/huginn-proxy-lib/tests/helpers.rs
+++ b/huginn-proxy-lib/tests/helpers.rs
@@ -57,7 +57,7 @@ pub fn create_valid_test_cert(
 
 /// Generate dummy (invalid) test certificates as DER (for direct use with rustls)
 ///
-/// The bytes are syntactically arbitrary — rustls will reject them.
+/// The bytes are syntactically arbitrary rustls will reject them.
 /// Use for tests that exercise the error path of `build_tls_acceptor` or
 /// similar functions without needing cryptographically valid material.
 pub fn generate_dummy_test_cert_der() -> (

--- a/huginn-proxy-lib/tests/proxy/h2c_forwarding.rs
+++ b/huginn-proxy-lib/tests/proxy/h2c_forwarding.rs
@@ -26,7 +26,7 @@ use tokio::net::TcpListener;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-/// Build an h2c-only client — identical settings to `ClientPool::create_http2_client`.
+/// Build an h2c-only client identical settings to `ClientPool::create_http2_client`.
 fn make_h2c_client() -> Client<HttpConnector, Empty<Bytes>> {
     let connector = HttpConnector::new();
     let mut builder = Client::builder(TokioExecutor::new());

--- a/huginn-proxy-lib/tests/tls/reloader.rs
+++ b/huginn-proxy-lib/tests/tls/reloader.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::helpers::{create_valid_test_cert, generate_dummy_test_cert_der};
 use huginn_proxy_lib::config::{ClientAuth, TlsConfig, TlsOptions};
 use huginn_proxy_lib::tls::build_cert_reloader;
@@ -60,6 +62,55 @@ async fn test_build_cert_reloader_missing_files(
     // Should fail because certificates must exist at startup
     let result = build_cert_reloader(&config, true, 60).await;
     assert!(result.is_err());
+    Ok(())
+}
+
+#[tokio::test]
+async fn watcher_updates_receiver_when_cert_files_change(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let (cert_path, key_path) = create_valid_test_cert()?;
+
+    let config = TlsConfig {
+        cert_path: cert_path.display().to_string(),
+        key_path: key_path.display().to_string(),
+        alpn: vec![],
+        options: TlsOptions::default(),
+        client_auth: ClientAuth::Disabled,
+        session_resumption: Default::default(),
+    };
+
+    let mut rx = build_cert_reloader(&config, true, 1).await?;
+    let initial = rx.borrow().clone().ok_or("initial cert value was None")?;
+
+    // Overwrite the files with a fresh cert — rcgen generates unique keys each time.
+    let rcgen::CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string()])?;
+    std::fs::write(&cert_path, cert.pem())?;
+    std::fs::write(&key_path, signing_key.serialize_pem())?;
+
+    // Wait up to 5 s for the watcher to pick up the change (debounce = 1 s).
+    match tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.changed().await {
+                Err(_) => return Err("watcher channel closed before cert changed"),
+                Ok(()) => {
+                    if rx.borrow().clone().is_some_and(|c| c != initial) {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    })
+    .await
+    {
+        Err(_) => return Err("cert reload did not happen within 5 seconds".into()),
+        Ok(Err(e)) => return Err(e.into()),
+        Ok(Ok(())) => {}
+    }
+
+    let _ = std::fs::remove_file(&cert_path);
+    let _ = std::fs::remove_file(&key_path);
+
     Ok(())
 }
 

--- a/huginn-proxy-lib/tests/tls/reloader.rs
+++ b/huginn-proxy-lib/tests/tls/reloader.rs
@@ -17,13 +17,11 @@ async fn test_build_cert_reloader() -> Result<(), Box<dyn std::error::Error + Se
         session_resumption: Default::default(),
     };
 
-    // This should succeed in creating the reloader service with valid certificates
     let result = build_cert_reloader(&config, true, 60).await;
 
     let _ = std::fs::remove_file(&cert_path);
     let _ = std::fs::remove_file(&key_path);
 
-    // Should succeed - reloader service is created with valid certificates
     let rx = match result {
         Ok(rx) => rx,
         Err(e) => panic!("build_cert_reloader should succeed with valid certificates: {e}"),
@@ -36,7 +34,6 @@ async fn test_build_cert_reloader() -> Result<(), Box<dyn std::error::Error + Se
 
     let alpn = vec!["h2".to_string()];
     let options = TlsOptions::default();
-    // With valid certs, this should also succeed
     let acceptor_result =
         certs_keys.build_tls_acceptor(&alpn, &options, &config.session_resumption);
     assert!(
@@ -59,7 +56,6 @@ async fn test_build_cert_reloader_missing_files(
         session_resumption: Default::default(),
     };
 
-    // Should fail because certificates must exist at startup
     let result = build_cert_reloader(&config, true, 60).await;
     assert!(result.is_err());
     Ok(())
@@ -82,13 +78,11 @@ async fn watcher_updates_receiver_when_cert_files_change(
     let mut rx = build_cert_reloader(&config, true, 1).await?;
     let initial = rx.borrow().clone().ok_or("initial cert value was None")?;
 
-    // Overwrite the files with a fresh cert — rcgen generates unique keys each time.
     let rcgen::CertifiedKey { cert, signing_key } =
         rcgen::generate_simple_self_signed(vec!["localhost".to_string()])?;
     std::fs::write(&cert_path, cert.pem())?;
     std::fs::write(&key_path, signing_key.serialize_pem())?;
 
-    // Wait up to 5 s for the watcher to pick up the change (debounce = 1 s).
     match tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.changed().await {
@@ -126,7 +120,6 @@ fn test_server_certs_keys_build_tls_acceptor(
     let alpn = vec!["h2".to_string()];
     let options = TlsOptions::default();
 
-    // This will fail because certs/key are invalid, but we test the function exists
     let result = server_certs_keys.build_tls_acceptor(&alpn, &options, &Default::default());
     assert!(result.is_err());
     Ok(())

--- a/huginn-proxy/src/main.rs
+++ b/huginn-proxy/src/main.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), BoxError> {
                 }
             }))
         } else {
-            info!("Metrics initialized (no metrics_port — Prometheus endpoint disabled)");
+            info!("Metrics initialized (no metrics_port, Prometheus endpoint disabled)");
             drop(registry);
             None
         };

--- a/tests-browsers/src/lib.rs
+++ b/tests-browsers/src/lib.rs
@@ -72,7 +72,7 @@ pub fn parse_backend_echo(
         Ok(headers)
     } else {
         Err(
-            format!("Failed to parse backend echo — no HTTP request line found. Content: {text}")
+            format!("Failed to parse backend echo no HTTP request line found. Content: {text}")
                 .into(),
         )
     }
@@ -101,7 +101,7 @@ pub fn get_http2_fingerprint(headers: &HashMap<String, String>) -> Option<&str> 
 
 // ── browser helpers ───────────────────────────────────────────────────────────
 
-/// Verify Chrome version (informational — does not fail).
+/// Verify Chrome version (informational does not fail).
 pub async fn verify_chrome_version(driver: &WebDriver) -> Result<(), Box<dyn std::error::Error>> {
     let user_agent: String = driver
         .execute("return navigator.userAgent;", vec![])

--- a/tests-e2e/src/common.rs
+++ b/tests-e2e/src/common.rs
@@ -53,7 +53,7 @@ impl BackendEcho {
                     )
                     && parts[2].starts_with("HTTP/")
                 {
-                    // Strip query string — whoami includes it in the request line
+                    // Strip query string whoami includes it in the request line
                     // but the proxy path tests only care about the path component.
                     let raw = parts[1];
                     path = Some(

--- a/tests-e2e/tests/fingerprint_isolation.rs
+++ b/tests-e2e/tests/fingerprint_isolation.rs
@@ -80,7 +80,7 @@ async fn test_fingerprint_isolation_from_added_headers(
         .ok_or("Custom header should be present")?;
     assert_eq!(custom_header1, "test-value-1", "Custom header value should match what we sent");
 
-    // Second request: with DIFFERENT custom headers — fingerprints must be identical
+    // Second request: with DIFFERENT custom headers fingerprints must be identical
     let response2 = client
         .get(PROXY_HTTPS_URL_IPV4)
         .header("X-Custom-Header", "test-value-2")


### PR DESCRIPTION
## What does this PR do?

Performance improvement: `read_certs_and_keys()` leaks the raw cert and key bytes on every call via `Box::leak()`.
With `HUGINN_WATCH=true` and automated certificate rotation (e.g. cert-manager), memory can grows unboundedly.