### PR TITLE
refactor: rename fingerprint headers from x-huginn-net-* to protocol-scoped names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,9 @@ First public release candidate.
 
 **Fingerprinting**
 
-- TLS (JA4) fingerprinting via ClientHello — injects `x-huginn-net-ja4`, `x-huginn-net-ja4_r`, `x-huginn-net-ja4_o`,
-  `x-huginn-net-ja4_or`, `x-huginn-net-ja4_s_v1`, `x-huginn-net-ja4_sr_v1`
-- HTTP/2 (Akamai) fingerprinting from SETTINGS and WINDOW_UPDATE frames — injects `x-huginn-net-akamai`
-- TCP SYN (p0f-style) fingerprinting via eBPF/XDP — injects `x-huginn-net-tcp` (requires `ebpf-tcp` build feature and
+- TLS (JA4) fingerprinting via ClientHello — injects `x-tls-ja4`, `x-tls-ja4-r`, `x-tls-ja4-o`, `x-tls-ja4-or`, `x-tls-ja4-sv1`, `x-tls-ja4-sv1r`
+- HTTP/2 (Akamai) fingerprinting from SETTINGS and WINDOW_UPDATE frames — injects `x-http2-akamai`
+- TCP SYN (p0f-style) fingerprinting via eBPF/XDP — injects `x-tcp-p0f` (requires `ebpf-tcp` build feature and
   Linux kernel ≥ 5.11)
 - Per-route `fingerprinting` toggle for TLS and HTTP/2; TCP SYN is global
 

--- a/EBPF-SETUP.md
+++ b/EBPF-SETUP.md
@@ -2,7 +2,7 @@
 
 TCP SYN fingerprinting is implemented via an XDP eBPF program that captures TCP SYN packets
 and stores them in a BPF LRU hash map. The proxy looks up each connection's SYN data and
-injects the `x-huginn-net-tcp` header with the p0f-style signature.
+injects the `x-tcp-p0f` header with the p0f-style signature.
 
 ---
 
@@ -15,7 +15,7 @@ TCP fingerprinting uses two separate processes:
   sidecar in Docker Compose). Requires elevated privileges but opens no ports.
 
 - **`huginn-proxy`** — opens the pinned BPF maps in read mode and injects the
-  `x-huginn-net-tcp` header. Runs as a standard Deployment with HPA.
+  `x-tcp-p0f` header. Runs as a standard Deployment with HPA.
 
 ```
   huginn-ebpf-agent                      huginn-proxy
@@ -23,7 +23,7 @@ TCP fingerprinting uses two separate processes:
   │ • Load XDP program       │           │ • Open pinned maps      │
   │ • Attach to interface   │           │   (read-only)           │
   │ • Pin maps to bpffs     │           │ • Lookup per connection  │
-  │ • Wait for SIGTERM      │           │ • Inject x-huginn-net-tcp│
+  │ • Wait for SIGTERM      │           │ • Inject x-tcp-p0f│
   └────────────┬────────────┘           └────────────▲───────────┘
                │                                       │
                │    /sys/fs/bpf/huginn/                │
@@ -207,7 +207,7 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for the full Kubernetes section.
 ## HTTP keep-alives
 
 XDP captures only TCP SYN packets. The fingerprint is looked up once at TCP accept time and
-reused for every request on that connection. As a result, **`x-huginn-net-tcp` is present on
+reused for every request on that connection. As a result, **`x-tcp-p0f` is present on
 all requests** of a keep-alive connection — not just the first.
 
 A `SynResult::Miss` (no header injected) happens when:

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -140,13 +140,13 @@ disabled).
 
 Passive fingerprinting extracts three types of signatures from client connections:
 
-- **TLS (JA4)** - extracted from the TLS ClientHello. Injected as `x-huginn-net-ja4` (sorted, hashed),
-  `x-huginn-net-ja4_r` (original order, hashed), `x-huginn-net-ja4_o` (sorted, raw), `x-huginn-net-ja4_or` (original
-  order, raw), `x-huginn-net-ja4_s_v1` (sorted, stable, hashed), `x-huginn-net-ja4_sr_v1`(original order, stable,
+- **TLS (JA4)** - extracted from the TLS ClientHello. Injected as `x-tls-ja4` (sorted, hashed),
+  `x-tls-ja4-r` (original order, hashed), `x-tls-ja4-o` (sorted, raw), `x-tls-ja4-or` (original
+  order, raw), `x-tls-ja4-sv1` (sorted, stable, hashed), `x-tls-ja4-sv1r` (original order, stable,
   hashed).
-- **HTTP/2 (Akamai)** - extracted from HTTP/2 SETTINGS and WINDOW_UPDATE frames. Injected as `x-huginn-net-akamai`.
+- **HTTP/2 (Akamai)** - extracted from HTTP/2 SETTINGS and WINDOW_UPDATE frames. Injected as `x-http2-akamai`.
 - **TCP SYN (p0f-style)** - extracted from the raw TCP SYN packet via an eBPF/XDP program attached to the network
-  interface. Injected as `x-huginn-net-tcp`. Requires the `ebpf-tcp` build feature and `tcp_enabled = true` in config.
+  interface. Injected as `x-tcp-p0f`. Requires the `ebpf-tcp` build feature and `tcp_enabled = true` in config.
 
 Per-route control to enable/disable TLS and HTTP/2 fingerprinting. TCP SYN fingerprinting is global (controlled by the
 `fingerprint.tcp_enabled` flag).

--- a/README.md
+++ b/README.md
@@ -75,18 +75,18 @@ For deployment instructions, see [DEPLOYMENT.md](DEPLOYMENT.md).
 
 Fingerprints are automatically extracted and injected as headers:
 
-- **TLS (JA4)**: `x-huginn-net-ja4`: sorted cipher suites and extensions, SHA-256 hashed. Standard FoxIO JA4.
+- **TLS (JA4)**: `x-tls-ja4`: sorted cipher suites and extensions, SHA-256 hashed. Standard FoxIO JA4.
   using [huginn-net-tls](https://crates.io/crates/huginn-net-tls)
-- **TLS (JA4_r)**: `x-huginn-net-ja4_r`: original ClientHello order, SHA-256 hashed (FoxIO JA4_r)
-- **TLS (JA4_o)**: `x-huginn-net-ja4_o`: sorted, raw hex values without hashing (FoxIO JA4_o, useful for debugging)
-- **TLS (JA4_or)**: `x-huginn-net-ja4_or`: original order, raw hex values without hashing (FoxIO JA4_or)
-- **TLS (JA4_s_v1)**: `x-huginn-net-ja4_s_v1`: sorted cipher suites and extensions, SHA-256 hashed — version-stable
+- **TLS (JA4_r)**: `x-tls-ja4-r`: original ClientHello order, SHA-256 hashed (FoxIO JA4_r)
+- **TLS (JA4_o)**: `x-tls-ja4-o`: sorted, raw hex values without hashing (FoxIO JA4_o, useful for debugging)
+- **TLS (JA4_or)**: `x-tls-ja4-or`: original order, raw hex values without hashing (FoxIO JA4_or)
+- **TLS (JA4_sv1)**: `x-tls-ja4-sv1`: sorted cipher suites and extensions, SHA-256 hashed — version-stable
   variant that excludes browser-version-specific fields for a fingerprint consistent across minor browser updates
-- **TLS (JA4_sr_v1)**: `x-huginn-net-ja4_sr_v1`: original ClientHello order, SHA-256 hashed — same stability guarantee
-  as JA4_s_v1 but preserving the raw extension ordering
-- **HTTP/2 (Akamai)**: `x-huginn-net-akamai`: Extracted from HTTP/2 connections only
+- **TLS (JA4_sv1r)**: `x-tls-ja4-sv1r`: original ClientHello order, SHA-256 hashed — same stability guarantee
+  as JA4_sv1 but preserving the raw extension ordering
+- **HTTP/2 (Akamai)**: `x-http2-akamai`: Extracted from HTTP/2 connections only
   using [huginn-net-http](https://crates.io/crates/huginn-net-http)
-- **TCP SYN (p0f-style)**: `x-huginn-net-tcp` - Raw TCP SYN signature extracted via eBPF/XDP
+- **TCP SYN (p0f-style)**: `x-tcp-p0f` - Raw TCP SYN signature extracted via eBPF/XDP
   using [huginn-net-tcp](https://crates.io/crates/huginn-net-tcp). Requires `tcp_enabled = true`
   and the `ebpf-tcp` feature. Present on all requests of a connection (the fingerprint is
   captured once at TCP accept time and reused). IPv4 and IPv6 SYNs are captured when the next
@@ -98,26 +98,26 @@ Fingerprints are automatically extracted and injected as headers:
 
 ```http
 # TLS — standard (FoxIO JA4)
-x-huginn-net-ja4:      t13d3112h2_e8f1e7e78f70_b26ce05bbdd6
-x-huginn-net-ja4_r:    t13d3112h2_002f,0033,...,ccaa_000a,..._0403,...
-x-huginn-net-ja4_o:    t13d3112h2_d7c3e2abb617_cad92ccb4254
-x-huginn-net-ja4_or:   t13d3112h2_1302,1303,..._0000,..._0403,...
+x-tls-ja4:      t13d3112h2_e8f1e7e78f70_b26ce05bbdd6
+x-tls-ja4-r:    t13d3112h2_002f,0033,...,ccaa_000a,..._0403,...
+x-tls-ja4-o:    t13d3112h2_d7c3e2abb617_cad92ccb4254
+x-tls-ja4-or:   t13d3112h2_1302,1303,..._0000,..._0403,...
 
 # TLS — stable (version-invariant)
-x-huginn-net-ja4_s_v1:  t13d3111h2_e8f1e7e78f70_375ca2c5e164
-x-huginn-net-ja4_sr_v1: t13d3111h2_002f,0033,...,ccaa_000a,..._0403,...
+x-tls-ja4-sv1:  t13d3111h2_e8f1e7e78f70_375ca2c5e164
+x-tls-ja4-sv1r: t13d3111h2_002f,0033,...,ccaa_000a,..._0403,...
 
 # HTTP/2 (Akamai)
-x-huginn-net-akamai:   3:100;4:10485760;2:0|1048510465|0|m,s,a,p
+x-http2-akamai:   3:100;4:10485760;2:0|1048510465|0|m,s,a,p
 
 # TCP SYN (eBPF/XDP)
-x-huginn-net-tcp:      4:64+0:0:1460:mss*44,7:mss,sok,ts,nop,ws:df,id+:0
+x-tcp-p0f: 4:64+0:0:1460:mss*44,7:mss,sok,ts,nop,ws:df,id+:0
 
 # Forwarded
-x-forwarded-for:       172.18.0.1
-x-forwarded-host:      localhost
-x-forwarded-port:      50908
-x-forwarded-proto:     https
+x-forwarded-for:   172.18.0.1
+x-forwarded-host:  localhost
+x-forwarded-port:  50908
+x-forwarded-proto: https
 ```
 
 These headers always override any client-provided values to prevent spoofing.
@@ -143,9 +143,9 @@ For module structure and design decisions, see [ARCHITECTURE.md](ARCHITECTURE.md
 
 | Fingerprint     | Header                | eBPF agent required                 |
 |-----------------|-----------------------|-------------------------------------|
-| TLS (JA4)       | `x-huginn-net-ja4`    | No                                  |
-| HTTP/2 (Akamai) | `x-huginn-net-akamai` | No                                  |
-| TCP SYN (p0f)   | `x-huginn-net-tcp`    | **Yes** - Linux only, kernel ≥ 5.11 |
+| TLS (JA4)       | `x-tls-ja4`           | No                                  |
+| HTTP/2 (Akamai) | `x-http2-akamai`      | No                                  |
+| TCP SYN (p0f)   | `x-tcp-p0f`   | **Yes** - Linux only, kernel ≥ 5.11 |
 
 **GHCR:** three container packages ([
 `huginn-proxy`](https://github.com/biandratti/huginn-proxy/pkgs/container/huginn-proxy), [
@@ -154,7 +154,7 @@ For module structure and design decisions, see [ARCHITECTURE.md](ARCHITECTURE.md
 How many you run depends on the setup:
 
 - **Proxy + eBPF agent (TCP SYN):** **`huginn-proxy`** + **`huginn-proxy-ebpf-agent`** two containers; JA4, Akamai, and
-  `x-huginn-net-tcp`.
+  `x-tcp-p0f`.
 - **Proxy only (no TCP SYN):** **`huginn-proxy-plain`** one container; JA4 and Akamai, no kernel SYN path.
 
 ## License

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -213,7 +213,7 @@ Path-prefix routing rules. **First match wins** — order matters. **Dynamic** (
 |------------------------|--------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `prefix`               | string | —       | URL path prefix to match. Use `"/"` as a catch-all default route.                                                                                                                              |
 | `backend`              | string | —       | Backend address to forward to. Must match a `[[backends]].address` exactly.                                                                                                                    |
-| `fingerprinting`       | bool   | `true`  | Inject TLS/HTTP fingerprint headers (`x-huginn-net-*`) for this route.                                                                                                                         |
+| `fingerprinting`       | bool   | `true`  | Inject TLS/HTTP fingerprint headers (`x-tls-ja4*`, `x-http2-akamai`, `x-tcp-p0f`) for this route.                                                                                                                         |
 | `force_new_connection` | bool   | `false` | Bypass the connection pool — opens a fresh TCP+TLS connection per request. Required when you need a fresh TLS handshake for each request (e.g. JA4 extraction on every request). Adds latency. |
 | `replace_path`         | string | `null`  | Path prefix replacement. Empty string (`""`) strips the prefix. Any other value replaces the matched prefix. Absent = forward as-is.                                                           |
 | `rate_limit`           | table  | —       | Per-route rate limit overrides. See [`[routes.rate_limit]`](#routesrate_limit) below.                                                                                                          |
@@ -660,9 +660,9 @@ Feature flags for passive fingerprinting. **Static** — eBPF programs are loade
 
 | Key            | Type    | Default | Description                                                                                                                                                |
 |----------------|---------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `tls_enabled`  | bool    | `true`  | Extract TLS (JA4) fingerprints and inject `x-huginn-net-ja4*` headers.                                                                                     |
-| `http_enabled` | bool    | `true`  | Extract HTTP/2 (Akamai) fingerprints and inject `x-huginn-net-akamai` header.                                                                              |
-| `tcp_enabled`  | bool    | `false` | Extract TCP SYN (p0f-style) fingerprints via eBPF/XDP and inject `x-huginn-net-tcp` header. Requires the `ebpf-tcp` build feature and Linux kernel ≥ 5.11. |
+| `tls_enabled`  | bool    | `true`  | Extract TLS (JA4) fingerprints and inject `x-tls-ja4*` headers.                                                                                     |
+| `http_enabled` | bool    | `true`  | Extract HTTP/2 (Akamai) fingerprints and inject `x-http2-akamai` header.                                                                              |
+| `tcp_enabled`  | bool    | `false` | Extract TCP SYN (p0f-style) fingerprints via eBPF/XDP and inject `x-tcp-p0f` header. Requires the `ebpf-tcp` build feature and Linux kernel ≥ 5.11. |
 | `max_capture`  | integer | `65536` | Maximum bytes captured per HTTP/2 connection for fingerprinting.                                                                                           |
 
 <table>

--- a/benches/README.md
+++ b/benches/README.md
@@ -146,7 +146,7 @@ Everything runs in-process on localhost. No Docker, no external services.
 the H2 delta isolates JA4 + Akamai cost together.
 
 **Fingerprint value assertion**: every fingerprinted request asserts that
-`x-huginn-net-ja4` (and `x-huginn-net-akamai` for HTTP/2) matches the values
+`x-tls-ja4` (and `x-http2-akamai` for HTTP/2) matches the values
 captured in `benches/fixtures/fingerprint_values.txt`. If either changes after a
 dependency update, the bench panics with a message pointing to `capture_fixtures`.
 

--- a/benches/bench_proxy.rs
+++ b/benches/bench_proxy.rs
@@ -48,8 +48,8 @@ use tokio::net::TcpListener;
 // ---------------------------------------------------------------------------
 // Fingerprint header names (mirrors huginn_proxy_lib::fingerprinting::names)
 // ---------------------------------------------------------------------------
-const HEADER_JA4: &str = "x-huginn-net-ja4";
-const HEADER_AKAMAI: &str = "x-huginn-net-akamai";
+const HEADER_JA4: &str = "x-tls-ja4";
+const HEADER_AKAMAI: &str = "x-http2-akamai";
 
 // ---------------------------------------------------------------------------
 // Expected fingerprint values - captured from a real reqwest/rustls connection.

--- a/benches/load/k6/fingerprints.js
+++ b/benches/load/k6/fingerprints.js
@@ -127,43 +127,43 @@ export default function () {
         const ja4Pattern = /^[tq]\d{2}[a-z]\d{4}[a-z0-9]{2}_[0-9a-f]+_[0-9a-f]+$/;
 
         check(null, {
-            "echo: x-huginn-net-ja4 valid": () => {
-                const v = headers["x-huginn-net-ja4"];
+            "echo: x-tls-ja4 valid": () => {
+                const v = headers["x-tls-ja4"];
                 return typeof v === "string" && ja4Pattern.test(v);
             },
         });
 
         check(null, {
-            "echo: x-huginn-net-ja4_r present": () => {
-                const v = headers["x-huginn-net-ja4_r"];
+            "echo: x-tls-ja4-r present": () => {
+                const v = headers["x-tls-ja4-r"];
                 return typeof v === "string" && v.length > 0;
             },
         });
 
         check(null, {
-            "echo: x-huginn-net-ja4_o present": () => {
-                const v = headers["x-huginn-net-ja4_o"];
+            "echo: x-tls-ja4-o present": () => {
+                const v = headers["x-tls-ja4-o"];
                 return typeof v === "string" && v.length > 0;
             },
         });
 
         check(null, {
-            "echo: x-huginn-net-ja4_or present": () => {
-                const v = headers["x-huginn-net-ja4_or"];
+            "echo: x-tls-ja4-or present": () => {
+                const v = headers["x-tls-ja4-or"];
                 return typeof v === "string" && v.length > 0;
             },
         });
 
         check(null, {
-            "echo: x-huginn-net-ja4_s_v1 valid": () => {
-                const v = headers["x-huginn-net-ja4_s_v1"];
+            "echo: x-tls-ja4-sv1 valid": () => {
+                const v = headers["x-tls-ja4-sv1"];
                 return typeof v === "string" && ja4Pattern.test(v);
             },
         });
 
         check(null, {
-            "echo: x-huginn-net-ja4_sr_v1 present": () => {
-                const v = headers["x-huginn-net-ja4_sr_v1"];
+            "echo: x-tls-ja4-sv1r present": () => {
+                const v = headers["x-tls-ja4-sv1r"];
                 return typeof v === "string" && v.length > 0;
             },
         });
@@ -174,8 +174,8 @@ export default function () {
         // e.g. 1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p
         const akamaiPattern = /^[\d:;]+\|\d+\|\d+\|[mapsi,]+$/;
         check(null, {
-            "echo: x-huginn-net-akamai valid (HTTP/2)": () => {
-                const v = headers["x-huginn-net-akamai"];
+            "echo: x-http2-akamai valid (HTTP/2)": () => {
+                const v = headers["x-http2-akamai"];
                 return typeof v === "string" && akamaiPattern.test(v);
             },
         });
@@ -184,8 +184,8 @@ export default function () {
     if (checkTcpSyn) {
         // TCP SYN format starts with IP version: 4: or 6:
         check(null, {
-            "echo: x-huginn-net-tcp valid (eBPF)": () => {
-                const v = headers["x-huginn-net-tcp"];
+            "echo: x-tcp-p0f valid (eBPF)": () => {
+                const v = headers["x-tcp-p0f"];
                 return typeof v === "string" && (v.startsWith("4:") || v.startsWith("6:"));
             },
         });

--- a/benches/load/k6/fingerprints.js
+++ b/benches/load/k6/fingerprints.js
@@ -96,6 +96,21 @@ function parseWhoami(text) {
     return inHeaders ? headers : null;
 }
 
+// FoxIO JA4 line: t|q + version + proto + ciphers + _ + hex + _ + hex
+const JA4_LINE_PATTERN = /^[tq]\d{2}[a-z]\d{4}[a-z0-9]{2}_[0-9a-f]+_[0-9a-f]+$/;
+// Akamai HTTP/2: SETTINGS|WINDOW_UPDATE|PRIORITY|pseudo-headers
+const AKAMAI_PATTERN = /^[\d:;]+\|\d+\|\d+\|[mapsi,]+$/;
+
+function headerMatchesJa4Line(h, name) {
+    const v = h[name];
+    return typeof v === "string" && JA4_LINE_PATTERN.test(v);
+}
+
+function headerNonEmpty(h, name) {
+    const v = h[name];
+    return typeof v === "string" && v.length > 0;
+}
+
 export default function () {
     const url =
         baseUrl.endsWith("/") && targetPath.startsWith("/")
@@ -122,70 +137,29 @@ export default function () {
     }
 
     if (checkJa4) {
-        // JA4 format: t<version><proto><ciphers>_<hash>_<hash>
-        // e.g. t13d1516h2_8daaf6152771_d8a2da3f94cd
-        const ja4Pattern = /^[tq]\d{2}[a-z]\d{4}[a-z0-9]{2}_[0-9a-f]+_[0-9a-f]+$/;
-
-        check(null, {
-            "echo: x-tls-ja4 valid": () => {
-                const v = headers["x-tls-ja4"];
-                return typeof v === "string" && ja4Pattern.test(v);
-            },
-        });
-
-        check(null, {
-            "echo: x-tls-ja4-r present": () => {
-                const v = headers["x-tls-ja4-r"];
-                return typeof v === "string" && v.length > 0;
-            },
-        });
-
-        check(null, {
-            "echo: x-tls-ja4-o present": () => {
-                const v = headers["x-tls-ja4-o"];
-                return typeof v === "string" && v.length > 0;
-            },
-        });
-
-        check(null, {
-            "echo: x-tls-ja4-or present": () => {
-                const v = headers["x-tls-ja4-or"];
-                return typeof v === "string" && v.length > 0;
-            },
-        });
-
-        check(null, {
-            "echo: x-tls-ja4-sv1 valid": () => {
-                const v = headers["x-tls-ja4-sv1"];
-                return typeof v === "string" && ja4Pattern.test(v);
-            },
-        });
-
-        check(null, {
-            "echo: x-tls-ja4-sv1r present": () => {
-                const v = headers["x-tls-ja4-sv1r"];
-                return typeof v === "string" && v.length > 0;
-            },
+        check(headers, {
+            "echo: x-tls-ja4 valid": (h) => headerMatchesJa4Line(h, "x-tls-ja4"),
+            "echo: x-tls-ja4-r present": (h) => headerNonEmpty(h, "x-tls-ja4-r"),
+            "echo: x-tls-ja4-o present": (h) => headerMatchesJa4Line(h, "x-tls-ja4-o"),
+            "echo: x-tls-ja4-or present": (h) => headerNonEmpty(h, "x-tls-ja4-or"),
+            "echo: x-tls-ja4-sv1 valid": (h) => headerMatchesJa4Line(h, "x-tls-ja4-sv1"),
+            "echo: x-tls-ja4-sv1r present": (h) => headerNonEmpty(h, "x-tls-ja4-sv1r"),
         });
     }
 
     if (checkAkamai) {
-        // Akamai HTTP/2 format: SETTINGS|WINDOW_UPDATE|PRIORITY|pseudo-headers
-        // e.g. 1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p
-        const akamaiPattern = /^[\d:;]+\|\d+\|\d+\|[mapsi,]+$/;
-        check(null, {
-            "echo: x-http2-akamai valid (HTTP/2)": () => {
-                const v = headers["x-http2-akamai"];
-                return typeof v === "string" && akamaiPattern.test(v);
+        check(headers, {
+            "echo: x-http2-akamai valid (HTTP/2)": (h) => {
+                const v = h["x-http2-akamai"];
+                return typeof v === "string" && AKAMAI_PATTERN.test(v);
             },
         });
     }
 
     if (checkTcpSyn) {
-        // TCP SYN format starts with IP version: 4: or 6:
-        check(null, {
-            "echo: x-tcp-p0f valid (eBPF)": () => {
-                const v = headers["x-tcp-p0f"];
+        check(headers, {
+            "echo: x-tcp-p0f valid (eBPF)": (h) => {
+                const v = h["x-tcp-p0f"];
                 return typeof v === "string" && (v.startsWith("4:") || v.startsWith("6:"));
             },
         });

--- a/examples/README.md
+++ b/examples/README.md
@@ -294,12 +294,12 @@ curl -sk https://127.0.0.1:7000/api/test
 
 Expected headers:
 
-- `x-huginn-net-ja4`: TLS fingerprint, sorted ciphers/extensions, hashed (FoxIO JA4)
-- `x-huginn-net-ja4_r`: TLS fingerprint, original ClientHello order, hashed (FoxIO JA4_r)
-- `x-huginn-net-ja4_o`: TLS fingerprint, sorted, raw hex values (FoxIO JA4_o)
-- `x-huginn-net-ja4_or`: TLS fingerprint, original order, raw hex values (FoxIO JA4_or)
-- `x-huginn-net-akamai`: HTTP/2 fingerprint
-- `x-huginn-net-tcp`: TCP SYNC fingerprint
+- `x-tls-ja4`: TLS fingerprint, sorted ciphers/extensions, hashed (FoxIO JA4)
+- `x-tls-ja4-r`: TLS fingerprint, original ClientHello order, hashed (FoxIO JA4_r)
+- `x-tls-ja4-o`: TLS fingerprint, sorted, raw hex values (FoxIO JA4_o)
+- `x-tls-ja4-or`: TLS fingerprint, original order, raw hex values (FoxIO JA4_or)
+- `x-http2-akamai`: HTTP/2 fingerprint
+- `x-tcp-p0f`: TCP SYN fingerprint
 
 ---
 

--- a/huginn-proxy-lib/src/fingerprinting/headers.rs
+++ b/huginn-proxy-lib/src/fingerprinting/headers.rs
@@ -6,28 +6,28 @@ pub mod names {
     ///
     /// This header contains the JA4 fingerprint normalized from the TLS ClientHello.
     /// It is injected for all TLS connections when fingerprinting is enabled.
-    pub const TLS_JA4: &str = "x-huginn-net-ja4";
+    pub const TLS_JA4: &str = "x-tls-ja4";
 
     /// Header name for TLS JA4_r fingerprint injection (FoxIO naming)
     ///
     /// JA4_r: cipher suites and extensions in original ClientHello, SHA-256 hashed.
     /// Differs from JA4 only in sort order of the B and C components.
     /// It is injected for all TLS connections when fingerprinting is enabled.
-    pub const TLS_JA4_R: &str = "x-huginn-net-ja4_r";
+    pub const TLS_JA4_R: &str = "x-tls-ja4-r";
 
     /// Header name for TLS JA4_o fingerprint injection (FoxIO naming)
     ///
     /// JA4_o: cipher suites and extensions sorted, raw (not hashed) hex values.
     /// Useful for debugging and forensic analysis without needing to reverse a hash.
     /// It is injected for all TLS connections when fingerprinting is enabled.
-    pub const TLS_JA4_O: &str = "x-huginn-net-ja4_o";
+    pub const TLS_JA4_O: &str = "x-tls-ja4-o";
 
     /// Header name for TLS JA4_or fingerprint injection (FoxIO naming)
     ///
     /// JA4_or: cipher suites and extensions in original ClientHello, raw (not hashed) hex values.
     /// Combines original order and raw values - maximum detail for analysis.
     /// It is injected for all TLS connections when fingerprinting is enabled.
-    pub const TLS_JA4_OR: &str = "x-huginn-net-ja4_or";
+    pub const TLS_JA4_OR: &str = "x-tls-ja4-or";
 
     /// Header name for TLS JA4_s1 stable fingerprint injection
     ///
@@ -36,7 +36,7 @@ pub mod names {
     /// Yields more consistent fingerprints across resumptions and TLS 1.3 flows from
     /// the same client than plain JA4, at the cost of omitting signal from those extensions.
     /// It is injected for all TLS connections when fingerprinting is enabled.
-    pub const TLS_JA4_S_V1: &str = "x-huginn-net-ja4_s_v1";
+    pub const TLS_JA4_S_V1: &str = "x-tls-ja4-sv1";
 
     /// Header name for TLS JA4_s1r stable fingerprint injection (raw variant)
     ///
@@ -44,13 +44,13 @@ pub mod names {
     /// ClientHello extension order and emits raw (not hashed) hex values — equivalent to
     /// the relationship between JA4_r and JA4.
     /// It is injected for all TLS connections when fingerprinting is enabled.
-    pub const TLS_JA4_SR_V1: &str = "x-huginn-net-ja4_sr_v1";
+    pub const TLS_JA4_SR_V1: &str = "x-tls-ja4-sv1r";
 
     /// Header name for HTTP/2 (Akamai) fingerprint injection
     ///
     /// This header contains the Akamai-style fingerprint extracted from HTTP/2 frames.
     /// It is only injected for HTTP/2 connections when fingerprinting is enabled.
-    pub const HTTP2_AKAMAI: &str = "x-huginn-net-akamai";
+    pub const HTTP2_AKAMAI: &str = "x-http2-akamai";
 
     /// Header name for TCP SYN p0f-style raw signature injection
     ///
@@ -58,7 +58,7 @@ pub mod names {
     /// Format: `"ver:ittl:olen:mss:wsize,wscale:olayout"`
     /// Example: `"4:64:0:1460:8192,6:mss,nop,ws,nop,nop,ts,sok"`
     /// Only injected when the `ebpf-tcp` feature is enabled and fingerprinting is configured.
-    pub const TCP_SYN: &str = "x-huginn-net-tcp";
+    pub const TCP_SYN: &str = "x-tcp-p0f";
 }
 
 /// HTTP header names for X-Forwarded-* headers

--- a/huginn-proxy-lib/tests/capture_fixtures.rs
+++ b/huginn-proxy-lib/tests/capture_fixtures.rs
@@ -141,19 +141,19 @@ async fn capture_fingerprint_values() -> Result<(), Box<dyn std::error::Error + 
                     let ja4 = Arc::clone(&ja4);
                     let akamai = Arc::clone(&akamai);
                     async move {
-                        if let Some(v) = req.headers().get("x-huginn-net-ja4") {
+                        if let Some(v) = req.headers().get("x-tls-ja4") {
                             *ja4.lock()
                                 .unwrap_or_else(|e| panic!("ja4 mutex poisoned: {e}")) =
                                 Some(v.to_str().unwrap_or("").to_string());
                         }
-                        if let Some(v) = req.headers().get("x-huginn-net-akamai") {
+                        if let Some(v) = req.headers().get("x-http2-akamai") {
                             *akamai
                                 .lock()
                                 .unwrap_or_else(|e| panic!("akamai mutex poisoned: {e}")) =
                                 Some(v.to_str().unwrap_or("").to_string());
                         }
                         let mut resp = Response::new(Full::new(Bytes::from("ok")));
-                        for name in ["x-huginn-net-ja4", "x-huginn-net-akamai"] {
+                        for name in ["x-tls-ja4", "x-http2-akamai"] {
                             if let Some(value) = req.headers().get(name) {
                                 resp.headers_mut().insert(
                                     hyper::header::HeaderName::from_bytes(name.as_bytes())
@@ -275,14 +275,14 @@ async fn capture_fingerprint_values() -> Result<(), Box<dyn std::error::Error + 
 
     let ja4_val = resp
         .headers()
-        .get("x-huginn-net-ja4")
+        .get("x-tls-ja4")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("(not present in response - check backend echo)")
         .to_string();
 
     let akamai_val = resp
         .headers()
-        .get("x-huginn-net-akamai")
+        .get("x-http2-akamai")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("(not present - HTTP/2 capture may need a second request)")
         .to_string();

--- a/tests-browsers/src/lib.rs
+++ b/tests-browsers/src/lib.rs
@@ -4,14 +4,14 @@ use std::collections::HashMap;
 use thirtyfour::prelude::*;
 
 pub const PROXY_URL: &str = "https://localhost:7000";
-pub const HEADER_HTTP2_AKAMAI: &str = "x-huginn-net-akamai";
-pub const HEADER_TLS_JA4: &str = "x-huginn-net-ja4";
-pub const HEADER_TLS_JA4_R: &str = "x-huginn-net-ja4_r";
-pub const HEADER_TLS_JA4_O: &str = "x-huginn-net-ja4_o";
-pub const HEADER_TLS_JA4_OR: &str = "x-huginn-net-ja4_or";
-pub const HEADER_TLS_JA4_S_V1: &str = "x-huginn-net-ja4_s_v1";
-pub const HEADER_TLS_JA4_SR_V1: &str = "x-huginn-net-ja4_sr_v1";
-pub const HEADER_TCP_SYN: &str = "x-huginn-net-tcp";
+pub const HEADER_HTTP2_AKAMAI: &str = "x-http2-akamai";
+pub const HEADER_TLS_JA4: &str = "x-tls-ja4";
+pub const HEADER_TLS_JA4_R: &str = "x-tls-ja4-r";
+pub const HEADER_TLS_JA4_O: &str = "x-tls-ja4-o";
+pub const HEADER_TLS_JA4_OR: &str = "x-tls-ja4-or";
+pub const HEADER_TLS_JA4_S_V1: &str = "x-tls-ja4-sv1";
+pub const HEADER_TLS_JA4_SR_V1: &str = "x-tls-ja4-sv1r";
+pub const HEADER_TCP_SYN: &str = "x-tcp-p0f";
 
 #[derive(Debug, Clone)]
 pub struct BrowserFingerprints {

--- a/tests-e2e/tests/security_headers.rs
+++ b/tests-e2e/tests/security_headers.rs
@@ -108,19 +108,19 @@ async fn test_security_headers_with_fingerprinting(
 
     let echo = parse_backend_echo(response).await?;
 
-    if let Some(ja4) = echo.header("x-huginn-net-ja4") {
+    if let Some(ja4) = echo.header("x-tls-ja4") {
         println!("JA4 fingerprint present: {}", ja4);
     }
-    if let Some(ja4_r) = echo.header("x-huginn-net-ja4_r") {
+    if let Some(ja4_r) = echo.header("x-tls-ja4-r") {
         println!("JA4_r fingerprint present: {}", ja4_r);
     }
-    if let Some(ja4_o) = echo.header("x-huginn-net-ja4_o") {
+    if let Some(ja4_o) = echo.header("x-tls-ja4-o") {
         println!("JA4_o fingerprint present: {}", ja4_o);
     }
-    if let Some(ja4_or) = echo.header("x-huginn-net-ja4_or") {
+    if let Some(ja4_or) = echo.header("x-tls-ja4-or") {
         println!("JA4_or fingerprint present: {}", ja4_or);
     }
-    if let Some(akamai) = echo.header("x-huginn-net-akamai") {
+    if let Some(akamai) = echo.header("x-http2-akamai") {
         println!("Akamai fingerprint present: {}", akamai);
     }
 
@@ -178,10 +178,10 @@ async fn test_security_headers_with_fingerprinting_ipv6(
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     let echo = parse_backend_echo(response).await?;
-    if let Some(ja4) = echo.header("x-huginn-net-ja4") {
+    if let Some(ja4) = echo.header("x-tls-ja4") {
         println!("IPv6 JA4 fingerprint present: {ja4}");
     }
-    if let Some(akamai) = echo.header("x-huginn-net-akamai") {
+    if let Some(akamai) = echo.header("x-http2-akamai") {
         println!("IPv6 Akamai fingerprint present: {akamai}");
     }
 

--- a/tests-e2e/tests/security_headers.rs
+++ b/tests-e2e/tests/security_headers.rs
@@ -1,9 +1,37 @@
+use huginn_proxy_lib::names;
 use reqwest::Client;
 
 use tests_e2e::common::{
-    parse_backend_echo, wait_for_service, DEFAULT_SERVICE_TIMEOUT_SECS, PROXY_HTTPS_URL_IPV4,
-    PROXY_HTTPS_URL_IPV6,
+    parse_backend_echo, wait_for_service, BackendEcho, DEFAULT_SERVICE_TIMEOUT_SECS,
+    PROXY_HTTPS_URL_IPV4, PROXY_HTTPS_URL_IPV6,
 };
+
+fn assert_injected_fingerprint_headers(echo: &BackendEcho, ipv6: bool) {
+    let prefix = if ipv6 { "IPv6 " } else { "" };
+
+    let tls: &[(&str, &str)] = &[
+        ("JA4", names::TLS_JA4),
+        ("JA4_r", names::TLS_JA4_R),
+        ("JA4_o", names::TLS_JA4_O),
+        ("JA4_or", names::TLS_JA4_OR),
+        ("JA4_sv1", names::TLS_JA4_S_V1),
+        ("JA4_sv1r", names::TLS_JA4_SR_V1),
+    ];
+
+    for (label, name) in tls {
+        let v = echo.header(name).unwrap_or_else(|| {
+            panic!("{prefix}expected injected header {name} ({label})");
+        });
+        assert!(!v.is_empty(), "{prefix}{name} ({label}) must be non-empty");
+        println!("{prefix}{label} fingerprint present: {v}");
+    }
+
+    let akamai = echo.header(names::HTTP2_AKAMAI).unwrap_or_else(|| {
+        panic!("{prefix}expected injected header {}", names::HTTP2_AKAMAI);
+    });
+    assert!(!akamai.is_empty(), "{prefix}HTTP/2 Akamai fingerprint must be non-empty");
+    println!("{prefix}Akamai fingerprint present: {akamai}");
+}
 
 #[tokio::test]
 async fn test_custom_security_headers() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -107,22 +135,7 @@ async fn test_security_headers_with_fingerprinting(
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     let echo = parse_backend_echo(response).await?;
-
-    if let Some(ja4) = echo.header("x-tls-ja4") {
-        println!("JA4 fingerprint present: {}", ja4);
-    }
-    if let Some(ja4_r) = echo.header("x-tls-ja4-r") {
-        println!("JA4_r fingerprint present: {}", ja4_r);
-    }
-    if let Some(ja4_o) = echo.header("x-tls-ja4-o") {
-        println!("JA4_o fingerprint present: {}", ja4_o);
-    }
-    if let Some(ja4_or) = echo.header("x-tls-ja4-or") {
-        println!("JA4_or fingerprint present: {}", ja4_or);
-    }
-    if let Some(akamai) = echo.header("x-http2-akamai") {
-        println!("Akamai fingerprint present: {}", akamai);
-    }
+    assert_injected_fingerprint_headers(&echo, false);
 
     Ok(())
 }
@@ -178,12 +191,7 @@ async fn test_security_headers_with_fingerprinting_ipv6(
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     let echo = parse_backend_echo(response).await?;
-    if let Some(ja4) = echo.header("x-tls-ja4") {
-        println!("IPv6 JA4 fingerprint present: {ja4}");
-    }
-    if let Some(akamai) = echo.header("x-http2-akamai") {
-        println!("IPv6 Akamai fingerprint present: {akamai}");
-    }
+    assert_injected_fingerprint_headers(&echo, true);
 
     Ok(())
 }


### PR DESCRIPTION
**What problem does this solve?**

Rename all injected fingerprint headers from the `x-huginn-net-*` prefix to protocol-scoped names that make the signal type explicit at a glance.
| Old | New |
|---|---|
| `x-huginn-net-ja4` | `x-tls-ja4` |
| `x-huginn-net-ja4_r` | `x-tls-ja4-r` |
| `x-huginn-net-ja4_o` | `x-tls-ja4-o` |
| `x-huginn-net-ja4_or` | `x-tls-ja4-or` |
| `x-huginn-net-ja4_s_v1` | `x-tls-ja4-sv1` |
| `x-huginn-net-ja4_sr_v1` | `x-tls-ja4-sv1r` |
| `x-huginn-net-akamai` | `x-http2-akamai` |
| `x-huginn-net-tcp` | `x-tcp-p0f` |
The `x-forwarded-*` headers are unchanged.

What you'd like to see. If you have a config or API shape in mind, sketch it out.

The `x-huginn-net-*` prefix gave no hint about which protocol layer or fingerprint type a header carried. The new names are self-documenting: the first segment (`tls`, `http2`, `tcp`) tells consumers the protocol
layer; the second segment (`ja4`, `akamai`, `p0f`) tells them the algorithm, making integration and debugging faster without consulting docs.