### PR TITLE
Deprecate huginn-db after refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,14 +118,14 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror 2.0.18",
@@ -180,15 +180,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -573,9 +573,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -594,7 +594,7 @@ checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
- "nom 7.1.3",
+ "nom",
  "num-bigint",
  "num-traits",
  "rusticata-macros",
@@ -671,9 +671,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -708,9 +708,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1010,7 +1010,6 @@ version = "0.0.1"
 dependencies = [
  "aya",
  "huginn-ebpf-common",
- "huginn-net-db",
  "huginn-net-tcp",
  "thiserror 2.0.18",
  "tracing",
@@ -1043,25 +1042,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "huginn-net-db"
-version = "1.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd10c7b115fd7961efa5e8d1503bae790527ade65aac10fc5d56fa6a498a8353"
-dependencies = [
- "nom 8.0.0",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
 name = "huginn-net-http"
-version = "1.7.5"
+version = "2.0.0-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa3a323c0807b1b8e0cf6ccb5627b23de5e577b4b5216b8ce9340d77e46608d"
+checksum = "b29d04e8911e69c05ebc452901291286c4a532c89bd682cfd27113bf53918ed1"
 dependencies = [
  "crossbeam-channel",
  "hpack-patched",
- "huginn-net-db",
  "lazy_static",
  "pcap-file",
  "pnet",
@@ -1073,24 +1060,22 @@ dependencies = [
 
 [[package]]
 name = "huginn-net-tcp"
-version = "1.7.5"
+version = "2.0.0-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71be314ec62993e0cbe813f8d8ba39eb3bce318ab8ab2bffb5490ab11cf06c31"
+checksum = "8dad15f3904be222ac72f4ceb87ffec28ae2d68c732ecfcffe79c2882260a5e4"
 dependencies = [
  "crossbeam-channel",
- "huginn-net-db",
  "pcap-file",
  "pnet",
  "thiserror 2.0.18",
  "tracing",
- "ttl_cache",
 ]
 
 [[package]]
 name = "huginn-net-tls"
-version = "1.7.5"
+version = "2.0.0-rc"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b532e76aec6119bf64f1f0c3cd812072fc077940092c6abfaf460d27bfcd56e"
+checksum = "76c6a239d44a66b375187555eddd6f6b678eec958fb5ebf96910870ec4c9c316"
 dependencies = [
  "crossbeam-channel",
  "pcap-file",
@@ -1124,7 +1109,6 @@ dependencies = [
  "criterion",
  "http",
  "http-body-util",
- "huginn-net-db",
  "huginn-net-http",
  "huginn-net-tcp",
  "huginn-net-tls",
@@ -1158,9 +1142,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1466,9 +1450,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1503,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags",
  "libc",
@@ -1652,21 +1636,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "nom-derive"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff943d68b88d0b87a6e0d58615e8fa07f9fd5a1319fa0a72efc1f62275c79a7"
 dependencies = [
- "nom 7.1.3",
+ "nom",
  "nom-derive-impl",
  "rustversion",
 ]
@@ -1730,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1903,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "pastey"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pcap-file"
@@ -2495,7 +2470,7 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
- "nom 7.1.3",
+ "nom",
 ]
 
 [[package]]
@@ -2699,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2948,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3154,7 +3129,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22c36249c6082584b1f224e70f6bdadf5102197be6cfa92b353efe605d9ac741"
 dependencies = [
- "nom 7.1.3",
+ "nom",
  "nom-derive",
  "num_enum",
  "phf",
@@ -3281,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3502,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3515,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3525,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3535,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3548,9 +3523,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -3604,9 +3579,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3855,9 +3830,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -3972,7 +3947,7 @@ dependencies = [
  "data-encoding",
  "der-parser",
  "lazy_static",
- "nom 7.1.3",
+ "nom",
  "oid-registry",
  "ring",
  "rusticata-macros",
@@ -4045,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,9 @@ criterion = { version = "0.8.2", features = ["html_reports"] }
 http = "1.4.0"
 http-body-util = "0.1.3"
 huginn-ebpf-common = { path = "huginn-ebpf-common" }
-huginn-net-db = "1.7.5"
-huginn-net-http = "1.7.5"
-huginn-net-tcp = "1.7.5"
-huginn-net-tls = { version = "1.7.5", features = ["stable-v1"] }
+huginn-net-http = { version = "2.0.0-rc", features = ["akamai"] }
+huginn-net-tcp = { version = "2.0.0-rc", features = ["syn"] }
+huginn-net-tls = { version = "2.0.0-rc", features = ["stable-v1"] }
 hyper = { version = "1.9.0", features = ["full"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 ipnet = "2.12.0"

--- a/huginn-ebpf/Cargo.toml
+++ b/huginn-ebpf/Cargo.toml
@@ -9,7 +9,6 @@ build = "src/build.rs"
 [dependencies]
 aya.workspace = true
 huginn-ebpf-common = { workspace = true, features = ["aya"] }
-huginn-net-db.workspace = true
 huginn-net-tcp.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/huginn-ebpf/src/types.rs
+++ b/huginn-ebpf/src/types.rs
@@ -1,7 +1,7 @@
-use huginn_net_db::observable_signals::TcpObservation;
-use huginn_net_db::tcp::{Quirk, Ttl, WindowSize};
 use huginn_net_tcp::syn_options::{parse_options_raw, ParsedTcpOptions};
 use huginn_net_tcp::tcp::{IpVersion, PayloadSize, TcpOption};
+use huginn_net_tcp::tcp::{Quirk, Ttl, WindowSize};
+use huginn_net_tcp::TcpObservation;
 use huginn_net_tcp::{ttl, window_size};
 use tracing::warn;
 

--- a/huginn-ebpf/tests/parse_syn.rs
+++ b/huginn-ebpf/tests/parse_syn.rs
@@ -1,5 +1,5 @@
 use huginn_ebpf::types::{parse_syn_v4, quirk_bits, SynRawDataV4};
-use huginn_net_db::tcp::Quirk;
+use huginn_net_tcp::tcp::Quirk;
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 

--- a/huginn-proxy-lib/Cargo.toml
+++ b/huginn-proxy-lib/Cargo.toml
@@ -11,7 +11,6 @@ arc-swap.workspace = true
 bytes.workspace = true
 http.workspace = true
 http-body-util.workspace = true
-huginn-net-db.workspace = true
 huginn-net-http.workspace = true
 huginn-net-tcp.workspace = true
 huginn-net-tls.workspace = true

--- a/huginn-proxy-lib/src/fingerprinting/mod.rs
+++ b/huginn-proxy-lib/src/fingerprinting/mod.rs
@@ -6,7 +6,7 @@ pub mod types;
 
 pub use headers::{forwarded, names};
 pub use http2_extractor::CapturingStream;
-pub use huginn_net_db::observable_signals::TcpObservation;
+pub use huginn_net_tcp::TcpObservation;
 pub use ja4::Ja4Fingerprints;
 pub use tls_extractor::read_client_hello;
 pub use types::SynResult;

--- a/huginn-proxy-lib/src/fingerprinting/types.rs
+++ b/huginn-proxy-lib/src/fingerprinting/types.rs
@@ -1,4 +1,4 @@
-use huginn_net_db::observable_signals::TcpObservation;
+use huginn_net_tcp::TcpObservation;
 
 /// Outcome of a TCP SYN fingerprint probe.
 ///


### PR DESCRIPTION
After complete refactor in huginn-net, now db can be removed from dependency. I have already applied reverse dependency.
