### PR TITLE
rate-limit aligned to Pingora

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1041,8 +1041,9 @@ Global rate limiting. **Dynamic** (hot-reloadable). Per-route overrides via `[ro
 | `requests_per_second` | integer | `1000`  | Sustained request rate allowed.                                                     |
 | `burst`               | integer | `2000`  | Maximum burst size above the sustained rate.                                        |
 | `window_seconds`      | integer | `1`     | Sliding window in seconds for the token bucket refill.                              |
-| `limit_by`            | string  | `"ip"`  | Key used to track limits: `"ip"`, `"header"`, `"route"`, `"combined"` (IP + route). |
-| `limit_by_header`     | string  | `null`  | Header name to use as the rate limit key when `limit_by = "header"`.                |
+| `limit_by`            | string       | `"ip"`  | Key used to track limits: `"ip"`, `"header"`, `"route"`, `"combined"` (IP + route). |
+| `limit_by_header`     | string       | `null`  | Header name to use as the rate limit key when `limit_by = "header"`.                |
+| `trusted_proxies`     | string array | `[]`    | Trusted reverse-proxy CIDRs. When empty (default), the TCP peer IP is always used as the rate-limit key — this is the secure default and cannot be spoofed. When set, `X-Forwarded-For` is walked right-to-left and the first IP **not** in this list is used, recovering the real client IP behind a trusted load balancer. Accepts CIDR notation. |
 
 <table>
 <thead>
@@ -1115,6 +1116,51 @@ security:
     burst: 400
     limit_by: "header"
     limit_by_header: "X-API-Key"
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
+<table>
+<thead>
+<tr>
+<th>TOML</th>
+<th>YAML</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td valign="top">
+
+```toml
+# Rate limit by real client IP behind a trusted load balancer.
+# Without trusted_proxies the TCP peer IP is used (secure default).
+# With trusted_proxies, XFF is walked right-to-left to find the
+# first non-trusted IP, which is treated as the client address.
+[security.rate_limit]
+enabled = true
+requests_per_second = 500
+burst = 1000
+limit_by = "ip"
+trusted_proxies = ["10.0.0.0/8", "172.16.0.0/12"]
+```
+
+</td>
+<td valign="top">
+
+```yaml
+# Rate limit by real client IP behind a trusted load balancer.
+security:
+  rate_limit:
+    enabled: true
+    requests_per_second: 500
+    burst: 1000
+    limit_by: "ip"
+    trusted_proxies:
+      - "10.0.0.0/8"
+      - "172.16.0.0/12"
 ```
 
 </td>

--- a/examples/config/compose.yaml
+++ b/examples/config/compose.yaml
@@ -81,6 +81,29 @@ routes:
   - prefix: "/api/e2e-unhealthy"
     backend: "unreachable-backend:9000"
 
+  # Dedicated routes for rate-limit E2E tests.
+  # burst=3 so the 4th request in a window always returns 429.
+  # No other E2E test uses these prefixes.
+  - prefix: "/rl"
+    backend: "backend-a:9000"
+    rate_limit:
+      enabled: true
+      requests_per_second: 1
+      burst: 3
+      window_seconds: 1
+      limit_by: "ip"
+
+  # Separate bucket for the XFF bypass-attempt test so state doesn't bleed
+  # between test cases.
+  - prefix: "/rl-bypass"
+    backend: "backend-a:9000"
+    rate_limit:
+      enabled: true
+      requests_per_second: 1
+      burst: 3
+      window_seconds: 1
+      limit_by: "ip"
+
   # Default catch-all
   - prefix: "/"
     backend: "backend-b:9000"

--- a/examples/config/rate-limit-example.toml
+++ b/examples/config/rate-limit-example.toml
@@ -77,6 +77,12 @@ limit_by = "ip"             # Rate limit by client IP address
 # limit_by = "header"
 # limit_by_header = "X-API-Key"  # Header name to use for rate limiting
 
+# Trusted reverse-proxy CIDRs (opt-in, default: empty).
+# When empty, the TCP connection IP is always used as the rate-limit key —
+# this is the secure default and cannot be spoofed by clients.
+# Uncomment and set to recover the real client IP behind a trusted load balancer:
+# trusted_proxies = ["10.0.0.0/8", "172.16.0.0/12"]
+
 # TLS configuration (optional)
 [tls]
 cert_path = "/config/certs/server.crt"
@@ -126,8 +132,8 @@ metrics_port = 9090  # Prometheus metrics endpoint
 #
 # 1. By IP (limit_by = "ip"):
 #    - Tracks requests per client IP address
-#    - Uses X-Forwarded-For header if present (for proxied requests)
-#    - Falls back to connection IP address
+#    - Secure default: uses the TCP connection IP, which clients cannot spoof
+#    - Set trusted_proxies to recover the real client IP behind a trusted load balancer
 #    - Best for: Public APIs, preventing DDoS attacks
 #
 # 2. By Header (limit_by = "header"):

--- a/huginn-proxy-lib/src/config/dynamic/security.rs
+++ b/huginn-proxy-lib/src/config/dynamic/security.rs
@@ -212,6 +212,19 @@ pub struct RateLimitConfig {
     /// Custom header name for "header" limit_by mode
     /// Required when limit_by = "header"
     pub limit_by_header: Option<String>,
+    /// Trusted reverse-proxy CIDRs for IP resolution (opt-in).
+    ///
+    /// When empty (default), the rate-limit key is always the TCP peer IP, the only
+    /// non-forgeable identity available. When non-empty, the `X-Forwarded-For` header
+    /// is walked right-to-left and the first IP that is NOT in this list is used as
+    /// the real client IP. This lets you recover the original client IP behind a
+    /// trusted load balancer without allowing clients to spoof the key by injecting
+    /// arbitrary XFF values.
+    ///
+    /// Accepts CIDR notation: ["10.0.0.0/8", "172.16.0.0/12", "::1/128"]
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_ip_networks")]
+    pub trusted_proxies: Vec<IpNet>,
 }
 
 impl Default for RateLimitConfig {
@@ -223,6 +236,7 @@ impl Default for RateLimitConfig {
             window_seconds: default_window_seconds(),
             limit_by: default_limit_by(),
             limit_by_header: None,
+            trusted_proxies: vec![],
         }
     }
 }
@@ -255,8 +269,9 @@ pub struct RouteRateLimitConfig {
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum LimitBy {
-    /// Rate limit by client IP address
-    /// Extracts IP from X-Forwarded-For or connection IP
+    /// Rate limit by client IP address.
+    /// Uses the TCP peer (connection) IP by default. When `trusted_proxies` is configured,
+    /// walks `X-Forwarded-For` right-to-left to find the first non-trusted IP.
     Ip,
     /// Rate limit by custom header value
     /// Requires limit_by_header to be specified

--- a/huginn-proxy-lib/src/proxy/handler/rate_limit_validation.rs
+++ b/huginn-proxy-lib/src/proxy/handler/rate_limit_validation.rs
@@ -44,6 +44,7 @@ pub fn check_rate_limit(
         route_match.matched_prefix,
         limit_by_header,
         headers,
+        &rate_limit_config.trusted_proxies,
     );
 
     let strategy = format!("{:?}", limit_by).to_lowercase();

--- a/huginn-proxy-lib/src/proxy/reload.rs
+++ b/huginn-proxy-lib/src/proxy/reload.rs
@@ -13,8 +13,8 @@ use tracing::{debug, error, info};
 
 /// Shared, hot-swappable rate-limit manager.
 ///
-/// - On reload with **no rate-limit change** → old manager is reused as-is (counters preserved).
-/// - On reload **with** rate-limit change → manager is rebuilt (counters reset).
+/// - On reload with no rate-limit or route change → old manager is reused as-is (counters preserved).
+/// - On reload with a rate-limit or route change → manager is rebuilt (counters reset).
 pub type SharedRateLimiter = Arc<ArcSwap<Option<Arc<RateLimitManager>>>>;
 
 /// Shared, hot-swappable HTTP client pool.

--- a/huginn-proxy-lib/src/proxy/reload.rs
+++ b/huginn-proxy-lib/src/proxy/reload.rs
@@ -79,13 +79,15 @@ pub async fn try_reload(
 
     audit_config_changes(&old_dynamic, &new_dynamic);
 
-    // rebuild rate-limiter only when the config actually changed
-    if old_dynamic.security.rate_limit != new_dynamic.security.rate_limit {
-        let new_mgr = if new_dynamic.security.rate_limit.enabled {
-            Some(Arc::new(RateLimitManager::new(
-                &new_dynamic.security.rate_limit,
-                &new_dynamic.routes,
-            )))
+    // Rebuild rate-limiter when the rate-limit config or routes change.
+    // Routes are included because per-route limiters are built from route definitions;
+    if old_dynamic.security.rate_limit != new_dynamic.security.rate_limit
+        || old_dynamic.routes != new_dynamic.routes
+    {
+        let candidate =
+            RateLimitManager::new(&new_dynamic.security.rate_limit, &new_dynamic.routes);
+        let new_mgr = if candidate.is_enabled() {
+            Some(Arc::new(candidate))
         } else {
             None
         };
@@ -237,8 +239,9 @@ fn fnv1a_hash(dynamic: &DynamicConfig) -> u64 {
 }
 
 pub fn initial_rate_limiter(dynamic: &DynamicConfig) -> SharedRateLimiter {
-    let mgr = if dynamic.security.rate_limit.enabled {
-        Some(Arc::new(RateLimitManager::new(&dynamic.security.rate_limit, &dynamic.routes)))
+    let candidate = RateLimitManager::new(&dynamic.security.rate_limit, &dynamic.routes);
+    let mgr = if candidate.is_enabled() {
+        Some(Arc::new(candidate))
     } else {
         None
     };

--- a/huginn-proxy-lib/src/proxy/shutdown.rs
+++ b/huginn-proxy-lib/src/proxy/shutdown.rs
@@ -83,7 +83,7 @@ impl fmt::Display for ServiceName {
 ///
 /// # Migration path to multi-runtime. Conditions are already prepared in case of using multi-runtime.
 /// Add a `runtime: tokio::runtime::Runtime` field and change `shutdown()` to
-/// call `self.runtime.shutdown_timeout(timeout)` — the same mechanism Pingora
+/// call `self.runtime.shutdown_timeout(timeout)`, the same mechanism Pingora
 /// uses. Every background task's `select!` loop and the `Vec<ServiceHandle>`
 /// collection in `run()` stay unchanged; only this impl changes.
 pub struct ServiceHandle {

--- a/huginn-proxy-lib/src/security/rate_limit/manager.rs
+++ b/huginn-proxy-lib/src/security/rate_limit/manager.rs
@@ -1,8 +1,9 @@
-use ahash::AHashMap;
-use std::time::Duration;
-
 use super::{RateLimitResult, RateLimiter};
 use crate::config::{LimitBy, RateLimitConfig, Route};
+use ahash::AHashMap;
+use ipnet::IpNet;
+use std::net::IpAddr;
+use std::time::Duration;
 
 /// Manager for rate limiters (global and per-route).
 ///
@@ -84,14 +85,48 @@ impl RateLimitManager {
     }
 }
 
-/// Extract rate limiting key from request context
+/// Resolve the effective client IP for rate limiting.
+///
+/// When `trusted_proxies` is empty, returns the TCP peer IP unconditionally,
+/// this is the secure default and cannot be spoofed by a client.
+///
+/// When `trusted_proxies` is non-empty and the peer itself is a trusted proxy,
+/// walks `X-Forwarded-For` right-to-left (our proxy appends the peer IP, so the
+/// rightmost entry is the most recently added and most trustworthy) and returns
+/// the first IP that it is NOT in the trusted set. Falls back to the peer IP if all
+/// XFF entries are trusted or the header is absent/malformed.
+fn resolve_client_ip(
+    peer: std::net::SocketAddr,
+    headers: &http::HeaderMap,
+    trusted_proxies: &[IpNet],
+) -> String {
+    let peer_ip = peer.ip();
+    if trusted_proxies.is_empty() || !trusted_proxies.iter().any(|net| net.contains(&peer_ip)) {
+        return peer_ip.to_string();
+    }
+    if let Some(xff) = headers.get("x-forwarded-for") {
+        if let Ok(xff_str) = xff.to_str() {
+            for raw in xff_str.rsplit(',') {
+                if let Ok(ip) = raw.trim().parse::<IpAddr>() {
+                    if !trusted_proxies.iter().any(|net| net.contains(&ip)) {
+                        return ip.to_string();
+                    }
+                }
+            }
+        }
+    }
+    peer_ip.to_string()
+}
+
+/// Extract rate limiting key from request context.
 ///
 /// # Arguments
 /// * `limit_by` - Key extraction strategy
-/// * `peer` - Client socket address
+/// * `peer` - Client socket address (TCP peer, non-forgeable)
 /// * `route_prefix` - Matched route prefix
 /// * `header_name` - Custom header name (for `LimitBy::Header`)
 /// * `headers` - HTTP request headers
+/// * `trusted_proxies` - CIDRs whose XFF additions are trusted (see `resolve_client_ip`)
 ///
 /// # Returns
 /// Rate limiting key as a string
@@ -101,19 +136,10 @@ pub fn extract_rate_limit_key(
     route_prefix: &str,
     header_name: Option<&str>,
     headers: &http::HeaderMap,
+    trusted_proxies: &[IpNet],
 ) -> String {
     match limit_by {
-        LimitBy::Ip => {
-            if let Some(xff) = headers.get("x-forwarded-for") {
-                if let Ok(xff_str) = xff.to_str() {
-                    if let Some(first_ip) = xff_str.split(',').next() {
-                        return first_ip.trim().to_string();
-                    }
-                }
-            }
-            // Fall back to peer IP
-            peer.ip().to_string()
-        }
+        LimitBy::Ip => resolve_client_ip(peer, headers, trusted_proxies),
         LimitBy::Header => {
             if let Some(name) = header_name {
                 if let Some(value) = headers.get(name) {
@@ -122,24 +148,11 @@ pub fn extract_rate_limit_key(
                     }
                 }
             }
-            // Fall back to IP if header not found
             peer.ip().to_string()
         }
-        LimitBy::Route => {
-            // Use route prefix as key (all clients share same limit)
-            route_prefix.to_string()
-        }
+        LimitBy::Route => route_prefix.to_string(),
         LimitBy::Combined => {
-            // Combine IP and route for per-IP, per-route limiting
-            let ip_str = if let Some(xff) = headers.get("x-forwarded-for") {
-                xff.to_str()
-                    .ok()
-                    .and_then(|s| s.split(',').next())
-                    .map(|s| s.trim().to_string())
-                    .unwrap_or_else(|| peer.ip().to_string())
-            } else {
-                peer.ip().to_string()
-            };
+            let ip_str = resolve_client_ip(peer, headers, trusted_proxies);
             format!("{ip_str}:{route_prefix}")
         }
     }

--- a/huginn-proxy-lib/tests/helpers.rs
+++ b/huginn-proxy-lib/tests/helpers.rs
@@ -12,7 +12,7 @@ use huginn_proxy_lib::{ShutdownSender, ShutdownWatch};
 /// Rust keeps it alive until the end of the scope instead of dropping it immediately.
 /// Dropping the sender closes the channel and causes any task that calls
 /// `shutdown_rx.wait_for(|v| *v)` to receive `Err`, which is treated as a
-/// shutdown signal — the task exits without doing any useful work.
+/// shutdown signal, the task exits without doing any useful work.
 ///
 /// # Example
 /// ```rust

--- a/huginn-proxy-lib/tests/security/mod.rs
+++ b/huginn-proxy-lib/tests/security/mod.rs
@@ -1,6 +1,7 @@
 pub mod headers;
 pub mod ip_filter;
 pub mod rate_limit;
+pub mod rate_limit_config;
 pub mod rate_limit_estimator;
 pub mod rate_limit_key;
 pub mod rate_limit_limiter;

--- a/huginn-proxy-lib/tests/security/mod.rs
+++ b/huginn-proxy-lib/tests/security/mod.rs
@@ -2,5 +2,6 @@ pub mod headers;
 pub mod ip_filter;
 pub mod rate_limit;
 pub mod rate_limit_estimator;
+pub mod rate_limit_key;
 pub mod rate_limit_limiter;
 pub mod rate_limit_rate;

--- a/huginn-proxy-lib/tests/security/rate_limit_config.rs
+++ b/huginn-proxy-lib/tests/security/rate_limit_config.rs
@@ -1,0 +1,25 @@
+use huginn_proxy_lib::config::RateLimitConfig;
+use ipnet::IpNet;
+
+#[test]
+fn default_trusted_proxies_is_empty() {
+    assert!(RateLimitConfig::default().trusted_proxies.is_empty());
+}
+
+#[test]
+fn deserialize_trusted_proxies_toml() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let toml = r#"
+        trusted_proxies = ["10.0.0.0/8", "172.16.0.0/12"]
+    "#;
+    let config: RateLimitConfig = toml::from_str(toml)?;
+    assert_eq!(config.trusted_proxies.len(), 2);
+    assert_eq!(config.trusted_proxies[0], "10.0.0.0/8".parse::<IpNet>()?);
+    assert_eq!(config.trusted_proxies[1], "172.16.0.0/12".parse::<IpNet>()?);
+    Ok(())
+}
+
+#[test]
+fn deserialize_invalid_cidr_errors() {
+    let toml = r#"trusted_proxies = ["not-a-cidr"]"#;
+    assert!(toml::from_str::<RateLimitConfig>(toml).is_err());
+}

--- a/huginn-proxy-lib/tests/security/rate_limit_key.rs
+++ b/huginn-proxy-lib/tests/security/rate_limit_key.rs
@@ -1,0 +1,167 @@
+use huginn_proxy_lib::config::LimitBy;
+use huginn_proxy_lib::security::extract_rate_limit_key;
+use ipnet::IpNet;
+
+fn peer(s: &str) -> std::net::SocketAddr {
+    s.parse()
+        .unwrap_or_else(|_| std::net::SocketAddr::from(([0, 0, 0, 0], 0)))
+}
+
+fn nets(cidrs: &[&str]) -> Vec<IpNet> {
+    cidrs.iter().filter_map(|s| s.parse().ok()).collect()
+}
+
+fn headers_with_xff(xff: &str) -> http::HeaderMap {
+    let mut h = http::HeaderMap::new();
+    if let Ok(hv) = http::header::HeaderValue::from_str(xff) {
+        h.insert(http::header::HeaderName::from_static("x-forwarded-for"), hv);
+    }
+    h
+}
+
+fn key_ip(peer_addr: std::net::SocketAddr, headers: &http::HeaderMap, proxies: &[IpNet]) -> String {
+    extract_rate_limit_key(LimitBy::Ip, peer_addr, "/", None, headers, proxies)
+}
+
+#[test]
+fn ip_no_trusted_uses_peer() {
+    // No trusted_proxies → always peer IP, even with XFF present.
+    assert_eq!(key_ip(peer("1.2.3.4:1234"), &headers_with_xff("9.9.9.9"), &[]), "1.2.3.4");
+}
+
+#[test]
+fn ip_spoof_rotation_pinned_to_peer() {
+    // Client rotates XFF values — result never changes without trusted_proxies.
+    let proxies: &[IpNet] = &[];
+    let p = peer("1.2.3.4:1234");
+    for xff in &["10.0.0.1", "172.16.0.1", "203.0.113.5, 10.0.0.1"] {
+        assert_eq!(key_ip(p, &headers_with_xff(xff), proxies), "1.2.3.4");
+    }
+}
+
+#[test]
+fn ip_untrusted_peer_ignores_xff() {
+    // trusted_proxies is set but the peer itself is NOT in the list → ignore XFF.
+    let proxies = nets(&["10.0.0.0/8"]);
+    assert_eq!(
+        key_ip(peer("8.8.8.8:80"), &headers_with_xff("203.0.113.5"), &proxies),
+        "8.8.8.8"
+    );
+}
+
+#[test]
+fn ip_trusted_peer_returns_real_client() {
+    // Peer is a trusted LB; XFF contains the real client IP.
+    let proxies = nets(&["10.0.0.0/8"]);
+    assert_eq!(
+        key_ip(peer("10.0.0.1:443"), &headers_with_xff("203.0.113.5"), &proxies),
+        "203.0.113.5"
+    );
+}
+
+#[test]
+fn ip_trusted_peer_multi_hop() {
+    // Two trusted hops; walk right-to-left past them to reach the real client.
+    // XFF: "client, trusted-lb-1, trusted-lb-2"  peer = trusted-lb-3
+    let proxies = nets(&["10.0.0.0/8"]);
+    let xff = "203.0.113.5, 10.0.0.2, 10.0.0.3";
+    assert_eq!(key_ip(peer("10.0.0.1:443"), &headers_with_xff(xff), &proxies), "203.0.113.5");
+}
+
+#[test]
+fn ip_trusted_peer_no_xff_falls_back() {
+    // Peer is trusted but XFF header is absent → fall back to peer IP.
+    let proxies = nets(&["10.0.0.0/8"]);
+    assert_eq!(key_ip(peer("10.0.0.1:443"), &http::HeaderMap::new(), &proxies), "10.0.0.1");
+}
+
+#[test]
+fn ip_trusted_peer_all_xff_trusted() {
+    // All XFF entries are also trusted → fall back to peer IP.
+    let proxies = nets(&["10.0.0.0/8"]);
+    let xff = "10.0.1.1, 10.0.2.2";
+    assert_eq!(key_ip(peer("10.0.0.1:443"), &headers_with_xff(xff), &proxies), "10.0.0.1");
+}
+
+#[test]
+fn ip_malformed_xff_falls_back() {
+    // Unparseable XFF entries are skipped; if all fail, fall back to peer IP.
+    let proxies = nets(&["10.0.0.0/8"]);
+    assert_eq!(
+        key_ip(peer("10.0.0.1:443"), &headers_with_xff("not-an-ip"), &proxies),
+        "10.0.0.1"
+    );
+}
+
+#[test]
+fn ip_xff_with_spaces() {
+    // Spaces around the comma separator must be trimmed.
+    let proxies = nets(&["10.0.0.0/8"]);
+    let xff = "  203.0.113.5  ,  10.0.0.2  ";
+    assert_eq!(key_ip(peer("10.0.0.1:443"), &headers_with_xff(xff), &proxies), "203.0.113.5");
+}
+
+#[test]
+fn ipv6_trusted_peer() {
+    let proxies = nets(&["fc00::/7"]);
+    let xff = "2001:db8::1";
+    assert_eq!(key_ip(peer("[fc00::1]:443"), &headers_with_xff(xff), &proxies), "2001:db8::1");
+}
+
+#[test]
+fn combined_no_trusted_uses_peer() {
+    let key = extract_rate_limit_key(
+        LimitBy::Combined,
+        peer("1.2.3.4:1234"),
+        "/api",
+        None,
+        &headers_with_xff("9.9.9.9"),
+        &[],
+    );
+    assert_eq!(key, "1.2.3.4:/api");
+}
+
+#[test]
+fn combined_trusted_returns_real_client() {
+    let proxies = nets(&["10.0.0.0/8"]);
+    let key = extract_rate_limit_key(
+        LimitBy::Combined,
+        peer("10.0.0.1:443"),
+        "/api",
+        None,
+        &headers_with_xff("203.0.113.5"),
+        &proxies,
+    );
+    assert_eq!(key, "203.0.113.5:/api");
+}
+
+#[test]
+fn header_strategy_unchanged() {
+    let mut h = http::HeaderMap::new();
+    h.insert(
+        http::header::HeaderName::from_static("x-api-key"),
+        http::header::HeaderValue::from_static("secret-token"),
+    );
+    let key = extract_rate_limit_key(
+        LimitBy::Header,
+        peer("1.2.3.4:1234"),
+        "/",
+        Some("x-api-key"),
+        &h,
+        &[],
+    );
+    assert_eq!(key, "secret-token");
+}
+
+#[test]
+fn route_strategy_unchanged() {
+    let key = extract_rate_limit_key(
+        LimitBy::Route,
+        peer("1.2.3.4:1234"),
+        "/api",
+        None,
+        &headers_with_xff("9.9.9.9"),
+        &[],
+    );
+    assert_eq!(key, "/api");
+}

--- a/huginn-proxy-lib/tests/security/rate_limit_key.rs
+++ b/huginn-proxy-lib/tests/security/rate_limit_key.rs
@@ -31,7 +31,7 @@ fn ip_no_trusted_uses_peer() {
 
 #[test]
 fn ip_spoof_rotation_pinned_to_peer() {
-    // Client rotates XFF values — result never changes without trusted_proxies.
+    // Client rotates XFF values, result never changes without trusted_proxies.
     let proxies: &[IpNet] = &[];
     let p = peer("1.2.3.4:1234");
     for xff in &["10.0.0.1", "172.16.0.1", "203.0.113.5, 10.0.0.1"] {

--- a/huginn-proxy-lib/tests/tls/cert_source.rs
+++ b/huginn-proxy-lib/tests/tls/cert_source.rs
@@ -479,7 +479,7 @@ async fn shutdown_ordering_background_tasks_exit_before_signal(
 
     // Signal shutdown, await the handle, then set the flag.
     // If anything logged after the flag was set and before tracing teardown
-    // would be lost — here we verify ordering without touching tracing.
+    // would be lost, here we verify ordering without touching tracing.
     let tasks_exited = StdArc::new(AtomicBool::new(false));
     let flag = StdArc::clone(&tasks_exited);
 

--- a/tests-e2e/tests/e2e.rs
+++ b/tests-e2e/tests/e2e.rs
@@ -16,6 +16,7 @@ mod header_override;
 mod health_checks;
 mod load_balance;
 mod path_manipulation;
+mod rate_limit;
 mod security_headers;
 mod tls;
 mod tls_cipher_curve_config;

--- a/tests-e2e/tests/rate_limit.rs
+++ b/tests-e2e/tests/rate_limit.rs
@@ -52,7 +52,7 @@ async fn test_rate_limit_xff_rotation_does_not_bypass(
     assert_eq!(
         limited,
         1,
-        "request {} must be rate-limited — XFF rotation must not bypass the limit (got {limited})",
+        "request {} must be rate-limited, XFF rotation must not bypass the limit (got {limited})",
         BURST + 1
     );
 

--- a/tests-e2e/tests/rate_limit.rs
+++ b/tests-e2e/tests/rate_limit.rs
@@ -1,0 +1,106 @@
+//! Rate-limit E2E tests.
+//!
+//! The `/rl` route in compose.yaml has burst=3, so the 4th request in a window
+//! must always return 429 regardless of what `X-Forwarded-For` says.
+//!
+//! The key assertion: we rotate `X-Forwarded-For` on every request (simulating
+//! client-side IP rotation). If the proxy used the leftmost XFF value as the
+//! rate-limit key (the old vulnerable behaviour), each request would be a new
+//! key and the limit would never fire. With the fix, the TCP peer IP is always
+//! used as the key (same for every request from this test process), so the
+//! bucket fills normally and the 4th request gets 429.
+
+use reqwest::StatusCode;
+use tests_e2e::common::{wait_for_service, DEFAULT_SERVICE_TIMEOUT_SECS, PROXY_HTTPS_URL_IPV4};
+
+const BURST: usize = 3;
+
+#[tokio::test]
+async fn test_rate_limit_xff_rotation_does_not_bypass(
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .map_err(|e| format!("Failed to build client: {e}"))?;
+
+    assert!(
+        wait_for_service(PROXY_HTTPS_URL_IPV4, DEFAULT_SERVICE_TIMEOUT_SECS).await?,
+        "proxy should be ready"
+    );
+
+    let url = format!("{PROXY_HTTPS_URL_IPV4}/rl");
+    let mut statuses = Vec::new();
+
+    // Send BURST+1 requests, each with a distinct XFF value to simulate IP rotation.
+    for i in 0..=BURST {
+        let resp = client
+            .get(&url)
+            .header("x-forwarded-for", format!("10.0.0.{}", i + 1))
+            .send()
+            .await
+            .map_err(|e| format!("Request {i} failed: {e}"))?;
+        statuses.push(resp.status());
+    }
+
+    let allowed = statuses.iter().filter(|s| s.is_success()).count();
+    let limited = statuses
+        .iter()
+        .filter(|s| **s == StatusCode::TOO_MANY_REQUESTS)
+        .count();
+
+    assert_eq!(allowed, BURST, "first {BURST} requests should be allowed (got {allowed})");
+    assert_eq!(
+        limited,
+        1,
+        "request {} must be rate-limited — XFF rotation must not bypass the limit (got {limited})",
+        BURST + 1
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_xff_bypass_attempt_is_blocked() -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+{
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .map_err(|e| format!("Failed to build client: {e}"))?;
+
+    assert!(
+        wait_for_service(PROXY_HTTPS_URL_IPV4, DEFAULT_SERVICE_TIMEOUT_SECS).await?,
+        "proxy should be ready"
+    );
+
+    // Use the dedicated /rl-bypass route so this test has its own fresh bucket.
+    let url = format!("{PROXY_HTTPS_URL_IPV4}/rl-bypass");
+
+    for i in 0..BURST {
+        let resp = client
+            .get(&url)
+            .header("x-forwarded-for", "10.10.10.1")
+            .send()
+            .await
+            .map_err(|e| format!("Phase-1 request {i} failed: {e}"))?;
+        assert!(
+            resp.status().is_success(),
+            "phase-1 request {i} should be allowed, got {}",
+            resp.status()
+        );
+    }
+
+    let bypass = client
+        .get(&url)
+        .header("x-forwarded-for", "99.99.99.99")
+        .send()
+        .await
+        .map_err(|e| format!("Bypass attempt failed: {e}"))?;
+
+    assert_eq!(
+        bypass.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "switching X-Forwarded-For must not reset the rate-limit bucket"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
  Security fix

  extract_rate_limit_key previously derived the rate-limit key from the leftmost X-Forwarded-For entry, which is fully client-controlled. An attacker could rotate arbitrary IPs in that header to appear as a new client on every request,
  trivially bypassing any IP-based rate limit.

  The key is now always derived from the TCP peer address (non-forgeable). X-Forwarded-For is only consulted when trusted_proxies is explicitly configured and the connecting peer is in that list.

  New config field — trusted_proxies
  
  [security.rate_limit]
  limit_by = "ip"
  trusted_proxies = ["10.0.0.0/8", "172.16.0.0/12"]
  When empty (default), peer IP is used unconditionally. When set, X-Forwarded-For is walked right-to-left and the first IP not in the trusted list is used as the real client IP — allowing rate limiting by true client identity behind a
  known load balancer without re-introducing spoofability. Hot-reloadable.

  Bug fixes (discovered while writing tests)
  
  - Per-route rate limits silently ignored when global is disabled — RateLimitManager was only instantiated when security.rate_limit.enabled = true. Routes with rate_limit.enabled = true had no effect. Fixed by constructing the manager
  unconditionally and checking is_enabled() on the result.
  - Hot-reload missed route-level rate-limit changes — the manager was only rebuilt when security.rate_limit changed, not when routes changed. Adding a route with rate limiting via config watch would update the router but leave the
  rate-limit buckets stale. Fixed by including routes in the rebuild condition.
