### PR TITLE
allow readines without backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ dependencies = [
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
  "prometheus",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -158,16 +158,16 @@ spec:
 
 ### Proxy (observability server)
 
-- `/health` - General health check
-- `/ready` - readiness probe (checks if proxy can accept traffic)
-- `/live` - liveness probe (checks if proxy is alive)
+- `/health` - general health check (alias of liveness, always 200 while running)
+- `/ready` - readiness probe: 200 once listeners are accepting connections; 503 while starting up and during graceful shutdown (fails first on SIGTERM so traffic drains cleanly).
+- `/live` - liveness probe (200 while the process is alive)
 - `/metrics` - Prometheus metrics
 
 ### eBPF agent (observability server)
 
-- `/health` - General health check
-- `/ready` - readiness probe: 200 if BPF map pins exist under `HUGINN_EBPF_PIN_PATH`
-- `/live` - liveness probe
+- `/health` - general health check (alias of liveness, always 200 while running)
+- `/ready` - readiness probe: 200 if BPF map pins exist under `HUGINN_EBPF_PIN_PATH`, 503 otherwise
+- `/live` - liveness probe (200 while the process is alive)
 - `/metrics` - Prometheus metrics
 
 ## Performance Tuning

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -105,9 +105,11 @@ For `limit_by = "ip"` / `"combined"`, the client IP is resolved from the global
 non-forgeable TCP peer IP is used.
 
 Precedence is **global → domain → route**, **whole-block replace** at every scope: a domain's `rate_limit` block fully
-replaces the global policy for that domain, and a route's block fully replaces the domain-effective policy for that route
+replaces the global policy for that domain, and a route's block fully replaces the domain-effective policy for that
+route
 (not a field-level merge — re-state every key you want to keep; e.g. a route block without `enabled = true` disables the
-limit for that route). Limiters are keyed per domain, so the same route prefix under two domains is tracked independently.
+limit for that route). Limiters are keyed per domain, so the same route prefix under two domains is tracked
+independently.
 
 Tracks limits in-memory, so restarting the proxy resets all counters.
 
@@ -119,7 +121,8 @@ Limitation: No distributed rate limiting across multiple proxy instances. Limits
 
 HSTS is configurable with max-age, includeSubdomains, and preload directives. CSP policies are customizable. Any custom
 header can be added to all responses. Security headers can be set globally (`[security.headers]`), **per-domain**
-(`[domains.security.headers]`), or **per-route** (`[domains.routes.security.headers]`); the most specific scope that sets
+(`[domains.security.headers]`), or **per-route** (`[domains.routes.security.headers]`); the most specific scope that
+sets
 the block replaces the parent's entirely (whole-block, not merged — a scope that sets only CSP does not inherit the
 parent's HSTS).
 
@@ -159,18 +162,30 @@ ClientHello SNI. Each `[[domains]]` entry carries its own `cert_path` / `key_pat
 catch-all (host-less) domain, and it is also served to clients that send no SNI (e.g. connecting by IP). When
 `[tls.options].sni_strict = true`, the default-cert fallback is disabled entirely (full parity with Traefik's
 `sniStrict`): both an SNI hostname that matches no configured domain **and** a connection that sends no SNI are
-rejected with `unrecognized_name` — IP-literal HTTPS clients no longer get the default cert in this mode. Default is `sni_strict = false`, where both cases fall back to the default cert. See the **Multi-Domain Routing** section below for how domains tie certificates to routes.
+rejected with `unrecognized_name` — IP-literal HTTPS clients no longer get the default cert in this mode. Default is
+`sni_strict = false`, where both cases fall back to the default cert. See the **Multi-Domain Routing** section below for
+how domains tie certificates to routes.
 
-**Misdirected-request enforcement (HTTP 421, always on).** Routing follows the request `:authority` / `Host`, not SNI, so
-a reused (coalesced) HTTP/2 connection could carry a request for a host served by a different certificate. Huginn rejects
-that with `421 Misdirected Request` — the same default protection nginx and Apache `mod_http2` apply (RFC 9110 §15.5.20 /
+**Misdirected-request enforcement (HTTP 421, always on).** Routing follows the request `:authority` / `Host`, not SNI,
+so
+a reused (coalesced) HTTP/2 connection could carry a request for a host served by a different certificate. Huginn
+rejects
+that with `421 Misdirected Request` — the same default protection nginx and Apache `mod_http2` apply (RFC 9110
+§15.5.20 /
 RFC 7540 §9.1.2). Because huginn uses a single global TLS configuration, "authoritative" reduces to "served by the same
-certificate": a request whose host is not covered by the certificate the connection's SNI selected is rejected. The check
-compares certificate coverage rather than literal `authority == SNI`, so hosts sharing a single certificate (a `*.example.com`
-wildcard, or distinct domains pointing at the same SAN cert file) still coalesce. It is not configurable — it only fires on
+certificate": a request whose host is not covered by the certificate the connection's SNI selected is rejected. The
+check
+compares certificate coverage rather than literal `authority == SNI`, so hosts sharing a single certificate (a
+`*.example.com`
+wildcard, or distinct domains pointing at the same SAN cert file) still coalesce. It is not configurable — it only fires
+on
 genuinely cross-certificate requests, and plain HTTP / no-SNI connections are unaffected.
 
-Certificates are re-read as part of a **config reload** — driven by SIGHUP or by a change to the *config file* (when the `--watch` file watcher is enabled, debounced by a configurable delay), not by an independent cert-file watcher. Each reload re-reads the cert/key files from their configured paths. The `DynamicCertResolver` is updated in place and its cert map is swapped atomically (`ArcSwap`); the acceptor's `ServerConfig` itself is built once at startup, so cipher suites, ALPN, client auth, and session resumption settings never drift between the initial configuration and reloaded
+Certificates are re-read as part of a **config reload** — driven by SIGHUP or by a change to the *config file* (when the
+`--watch` file watcher is enabled, debounced by a configurable delay), not by an independent cert-file watcher. Each
+reload re-reads the cert/key files from their configured paths. The `DynamicCertResolver` is updated in place and its
+cert map is swapped atomically (`ArcSwap`); the acceptor's `ServerConfig` itself is built once at startup, so cipher
+suites, ALPN, client auth, and session resumption settings never drift between the initial configuration and reloaded
 certificates.
 
 Reloading is **best-effort and per-domain** (Traefik-style): if one domain's new certificate fails to load, the other
@@ -235,7 +250,8 @@ Passive fingerprinting extracts three types of signatures from client connection
 
 Per-domain and per-route control to enable/disable TLS and HTTP/2 fingerprint **header injection**
 (`route.or(domain).unwrap_or(true)`; a route overrides its domain). Whether the signatures are *captured* at all is the
-static global `[fingerprint]` config. TCP SYN fingerprinting is global (controlled by the `fingerprint.tcp_enabled` flag).
+static global `[fingerprint]` config. TCP SYN fingerprinting is global (controlled by the `fingerprint.tcp_enabled`
+flag).
 
 The TCP SYN signature follows the p0f format: `ip_ver:ttl:ip_olen:mss:wsize,wscale:olayout:quirks:pclass`. Quirks
 extracted include IP-level flags (DF, ECN, reserved bit, IP ID anomalies) and TCP-level flags (zero-seq, non-zero ACK,
@@ -339,8 +355,10 @@ Request and backend metrics carry a `domain` label so traffic can be broken down
 pattern (e.g. `*.example.com`), keeping cardinality bounded by the number of configured domains rather than by request
 hosts.
 
-Health endpoints: `/health` (general), `/ready` (Kubernetes readiness), `/live` (Kubernetes liveness), `/metrics` (
-Prometheus).
+Health endpoints: `/health` (general, alias of liveness), `/ready` (Kubernetes readiness), `/live` (Kubernetes
+liveness), `/metrics` (Prometheus). `/live` and `/health` return 200 while the process runs. `/ready` returns 200 once
+the proxy's listeners are accepting connections and 503 while starting up or during graceful shutdown.
+The eBPF agent's `/ready` returns 200 once its BPF map pins are loaded.
 
 For the full metric list, labels, and example queries, see [TELEMETRY.md](TELEMETRY.md).
 

--- a/benches/bench_proxy.rs
+++ b/benches/bench_proxy.rs
@@ -186,6 +186,7 @@ impl BenchFixture {
                 None,
                 huginn_proxy_lib::WatchOptions::default(),
                 shutdown_tx,
+                huginn_proxy_lib::Readiness::new(),
             )
             .await;
         });

--- a/examples/README.md
+++ b/examples/README.md
@@ -195,17 +195,17 @@ matches; you may still need to accept the browser warning unless you use `mkcert
 
 ## Endpoints
 
-| Service    | URL                             | Description          |
-|------------|---------------------------------|----------------------|
-| Proxy      | `https://127.0.0.1:7000/`       | HTTPS proxy          |
-| Proxy      | `http://127.0.0.1:9090/health`  | Health               |
-| Proxy      | `http://127.0.0.1:9090/ready`   | Readiness            |
-| Proxy      | `http://127.0.0.1:9090/live`    | Liveness             |
-| Proxy      | `http://127.0.0.1:9090/metrics` | Prometheus metrics   |
-| eBPF Agent | `http://127.0.0.1:9091/health`  | Health               |
-| eBPF Agent | `http://127.0.0.1:9091/ready`   | Readiness (BPF pins) |
-| eBPF Agent | `http://127.0.0.1:9091/live`    | Liveness             |
-| eBPF Agent | `http://127.0.0.1:9091/metrics` | Prometheus metrics   |
+| Service    | URL                             | Description                       |
+|------------|---------------------------------|-----------------------------------|
+| Proxy      | `https://127.0.0.1:7000/`       | HTTPS proxy                       |
+| Proxy      | `http://127.0.0.1:9090/health`  | Health (liveness alias)           |
+| Proxy      | `http://127.0.0.1:9090/ready`   | Readiness (accepting connections) |
+| Proxy      | `http://127.0.0.1:9090/live`    | Liveness                          |
+| Proxy      | `http://127.0.0.1:9090/metrics` | Prometheus metrics                |
+| eBPF Agent | `http://127.0.0.1:9091/health`  | Health (liveness alias)           |
+| eBPF Agent | `http://127.0.0.1:9091/ready`   | Readiness (BPF pins loaded)       |
+| eBPF Agent | `http://127.0.0.1:9091/live`    | Liveness                          |
+| eBPF Agent | `http://127.0.0.1:9091/metrics` | Prometheus metrics                |
 
 eBPF compose examples map agent HTTP on the proxy service (`9091:9091`).
 

--- a/huginn-ebpf-agent/Cargo.toml
+++ b/huginn-ebpf-agent/Cargo.toml
@@ -17,6 +17,7 @@ opentelemetry.workspace = true
 opentelemetry-prometheus.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["metrics"] }
 prometheus.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "net", "signal", "macros"] }

--- a/huginn-ebpf-agent/src/error.rs
+++ b/huginn-ebpf-agent/src/error.rs
@@ -1,7 +1,5 @@
 //! Agent-wide error type.
 
-/// Errors produced by the eBPF agent: config parsing, eBPF program loading/pinning,
-/// metrics setup, and the observability HTTP server.
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
     #[error(transparent)]

--- a/huginn-ebpf-agent/src/error.rs
+++ b/huginn-ebpf-agent/src/error.rs
@@ -1,0 +1,23 @@
+//! Agent-wide error type.
+
+/// Errors produced by the eBPF agent: config parsing, eBPF program loading/pinning,
+/// metrics setup, and the observability HTTP server.
+#[derive(Debug, thiserror::Error)]
+pub enum AgentError {
+    #[error(transparent)]
+    Config(#[from] crate::config::ConfigError),
+
+    #[error("eBPF error: {0}")]
+    Ebpf(#[from] huginn_ebpf::EbpfError),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("metrics error: {0}")]
+    Metrics(String),
+
+    #[error("HTTP error: {0}")]
+    Http(String),
+}
+
+pub type Result<T> = std::result::Result<T, AgentError>;

--- a/huginn-ebpf-agent/src/main.rs
+++ b/huginn-ebpf-agent/src/main.rs
@@ -6,15 +6,17 @@
 #![forbid(unsafe_code)]
 
 mod config;
+mod error;
 mod healthchecks;
 mod telemetry;
 use crate::config::from_env;
+use crate::error::Result;
 use huginn_ebpf::EbpfProbe;
 use std::env;
 use std::sync::Arc;
 use tokio::signal;
 
-async fn wait_for_shutdown_signal() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn wait_for_shutdown_signal() -> Result<()> {
     let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
         .map_err(|e| std::io::Error::other(format!("Failed to setup SIGTERM handler: {e}")))?;
     let mut sigint = signal::unix::signal(signal::unix::SignalKind::interrupt())
@@ -27,7 +29,7 @@ async fn wait_for_shutdown_signal() -> Result<(), Box<dyn std::error::Error + Se
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn main() -> Result<()> {
     let default_level = env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level));

--- a/huginn-ebpf-agent/src/telemetry/health.rs
+++ b/huginn-ebpf-agent/src/telemetry/health.rs
@@ -1,73 +1,30 @@
 use crate::healthchecks;
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
-use hyper::body::Bytes;
+use crate::telemetry::http::{json_response, RespBody};
+use crate::telemetry::status::{Status, StatusBody};
 use hyper::Response;
 use hyper::StatusCode;
-use serde_json::json;
 use tracing::warn;
 
-type RespBody = BoxBody<Bytes, hyper::Error>;
-
 /// Health check, 200 if process is running.
-pub fn health_check_response(
-) -> Result<Response<RespBody>, Box<dyn std::error::Error + Send + Sync>> {
-    let body = json!({"status": "healthy"});
-    let body_bytes = serde_json::to_vec(&body)
-        .map_err(|e| format!("Failed to serialize health response: {e}"))?;
-    let body = Full::new(Bytes::from(body_bytes))
-        .map_err(|never| match never {})
-        .boxed();
-    let response = Response::builder()
-        .status(StatusCode::OK)
-        .header("Content-Type", "application/json")
-        .body(body)
-        .map_err(|e| format!("Failed to build response: {e}"))?;
-    Ok(response)
+pub fn health_check_response() -> Response<RespBody> {
+    json_response(StatusCode::OK, StatusBody::new(Status::Healthy))
 }
 
 /// Liveness check, 200 if process is running
-pub fn live_check_response() -> Result<Response<RespBody>, Box<dyn std::error::Error + Send + Sync>>
-{
-    let body = json!({"status": "alive"});
-    let body_bytes =
-        serde_json::to_vec(&body).map_err(|e| format!("Failed to serialize live response: {e}"))?;
-    let body = Full::new(Bytes::from(body_bytes))
-        .map_err(|never| match never {})
-        .boxed();
-    let response = Response::builder()
-        .status(StatusCode::OK)
-        .header("Content-Type", "application/json")
-        .body(body)
-        .map_err(|e| format!("Failed to build response: {e}"))?;
-    Ok(response)
+pub fn live_check_response() -> Response<RespBody> {
+    json_response(StatusCode::OK, StatusBody::new(Status::Alive))
 }
 
 /// Readiness check if BPF pins exist
-pub fn ready_check_response(
-    pin_path: &str,
-) -> Result<Response<RespBody>, Box<dyn std::error::Error + Send + Sync>> {
-    let (status, body) = if healthchecks::pins_exist(pin_path) {
-        (StatusCode::OK, json!({"status": "ready"}))
-    } else {
-        warn!(
-            pin_path,
-            reason = "pins_not_ready",
-            "Readiness check failed: BPF map pins are not present yet"
-        );
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            json!({"status": "not_ready", "reason": "pins_not_ready"}),
-        )
-    };
-    let body_bytes = serde_json::to_vec(&body)
-        .map_err(|e| format!("Failed to serialize ready response: {e}"))?;
-    let body = Full::new(Bytes::from(body_bytes))
-        .map_err(|never| match never {})
-        .boxed();
-    let response = Response::builder()
-        .status(status)
-        .header("Content-Type", "application/json")
-        .body(body)
-        .map_err(|e| format!("Failed to build response: {e}"))?;
-    Ok(response)
+pub fn ready_check_response(pin_path: &str) -> Response<RespBody> {
+    if healthchecks::pins_exist(pin_path) {
+        return json_response(StatusCode::OK, StatusBody::new(Status::Ready));
+    }
+
+    let reason = "pins_not_ready";
+    warn!(pin_path, reason, "Readiness check failed: BPF map pins are not present yet");
+    json_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        StatusBody::with_reason(Status::NotReady, reason),
+    )
 }

--- a/huginn-ebpf-agent/src/telemetry/health.rs
+++ b/huginn-ebpf-agent/src/telemetry/health.rs
@@ -4,6 +4,7 @@ use hyper::body::Bytes;
 use hyper::Response;
 use hyper::StatusCode;
 use serde_json::json;
+use tracing::warn;
 
 type RespBody = BoxBody<Bytes, hyper::Error>;
 
@@ -48,6 +49,11 @@ pub fn ready_check_response(
     let (status, body) = if healthchecks::pins_exist(pin_path) {
         (StatusCode::OK, json!({"status": "ready"}))
     } else {
+        warn!(
+            pin_path,
+            reason = "pins_not_ready",
+            "Readiness check failed: BPF map pins are not present yet"
+        );
         (
             StatusCode::SERVICE_UNAVAILABLE,
             json!({"status": "not_ready", "reason": "pins_not_ready"}),

--- a/huginn-ebpf-agent/src/telemetry/http.rs
+++ b/huginn-ebpf-agent/src/telemetry/http.rs
@@ -1,26 +1,17 @@
-//! Shared helpers for building boxed HTTP response bodies and JSON responses.
-//!
-//! Centralises the `BoxBody<Bytes, hyper::Error>` alias and the `Full` boxing dance
-//! (`Full` is infallible, so its `Infallible` error is mapped away) that would otherwise
-//! be duplicated across the observability handlers.
-
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::header::{HeaderValue, CONTENT_TYPE};
 use hyper::{Response, StatusCode};
 use serde::Serialize;
 
-/// Boxed response body used by the observability server.
 pub(crate) type RespBody = BoxBody<Bytes, hyper::Error>;
 
-/// Box a fixed byte buffer into a [`RespBody`].
 pub(crate) fn full_body(bytes: impl Into<Bytes>) -> RespBody {
     Full::new(bytes.into())
         .map_err(|never| match never {})
         .boxed()
 }
 
-/// Build an `application/json` response with the given status.
 pub(crate) fn json_response(status: StatusCode, body: impl Serialize) -> Response<RespBody> {
     let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
     let mut resp = Response::new(full_body(bytes));

--- a/huginn-ebpf-agent/src/telemetry/http.rs
+++ b/huginn-ebpf-agent/src/telemetry/http.rs
@@ -1,0 +1,31 @@
+//! Shared helpers for building boxed HTTP response bodies and JSON responses.
+//!
+//! Centralises the `BoxBody<Bytes, hyper::Error>` alias and the `Full` boxing dance
+//! (`Full` is infallible, so its `Infallible` error is mapped away) that would otherwise
+//! be duplicated across the observability handlers.
+
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::header::{HeaderValue, CONTENT_TYPE};
+use hyper::{Response, StatusCode};
+use serde::Serialize;
+
+/// Boxed response body used by the observability server.
+pub(crate) type RespBody = BoxBody<Bytes, hyper::Error>;
+
+/// Box a fixed byte buffer into a [`RespBody`].
+pub(crate) fn full_body(bytes: impl Into<Bytes>) -> RespBody {
+    Full::new(bytes.into())
+        .map_err(|never| match never {})
+        .boxed()
+}
+
+/// Build an `application/json` response with the given status.
+pub(crate) fn json_response(status: StatusCode, body: impl Serialize) -> Response<RespBody> {
+    let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
+    let mut resp = Response::new(full_body(bytes));
+    *resp.status_mut() = status;
+    resp.headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    resp
+}

--- a/huginn-ebpf-agent/src/telemetry/metrics.rs
+++ b/huginn-ebpf-agent/src/telemetry/metrics.rs
@@ -51,14 +51,13 @@ impl Metrics {
     }
 }
 
-pub fn init_metrics(
-    pin_path: Arc<String>,
-) -> Result<(Registry, Metrics), Box<dyn std::error::Error + Send + Sync>> {
+pub fn init_metrics(pin_path: Arc<String>) -> crate::error::Result<(Registry, Metrics)> {
     let registry = Registry::default();
 
     let exporter = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
-        .build()?;
+        .build()
+        .map_err(|e| crate::error::AgentError::Metrics(e.to_string()))?;
 
     let meter_provider = SdkMeterProvider::builder().with_reader(exporter).build();
     global::set_meter_provider(meter_provider);

--- a/huginn-ebpf-agent/src/telemetry/metrics_handler.rs
+++ b/huginn-ebpf-agent/src/telemetry/metrics_handler.rs
@@ -1,30 +1,20 @@
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
-use hyper::body::Bytes;
+use crate::error::{AgentError, Result};
+use crate::telemetry::http::{full_body, RespBody};
 use hyper::Response;
 use hyper::StatusCode;
 use prometheus::{Encoder, Registry, TextEncoder};
 
-type RespBody = BoxBody<Bytes, hyper::Error>;
-
-pub fn handle_metrics(
-    registry: &Registry,
-) -> Result<Response<RespBody>, Box<dyn std::error::Error + Send + Sync>> {
+pub fn handle_metrics(registry: &Registry) -> Result<Response<RespBody>> {
     let encoder = TextEncoder::new();
     let metric_families = registry.gather();
     let mut buffer = Vec::new();
     encoder
         .encode(&metric_families, &mut buffer)
-        .map_err(|e| format!("Failed to encode metrics: {e}"))?;
+        .map_err(|e| AgentError::Metrics(format!("Failed to encode metrics: {e}")))?;
 
-    let body = Full::new(Bytes::from(buffer))
-        .map_err(|never| match never {})
-        .boxed();
-
-    let response = Response::builder()
+    Response::builder()
         .status(StatusCode::OK)
         .header("Content-Type", encoder.format_type())
-        .body(body)
-        .map_err(|e| format!("Failed to build response: {e}"))?;
-
-    Ok(response)
+        .body(full_body(buffer))
+        .map_err(|e| AgentError::Http(format!("Failed to build response: {e}")))
 }

--- a/huginn-ebpf-agent/src/telemetry/mod.rs
+++ b/huginn-ebpf-agent/src/telemetry/mod.rs
@@ -1,6 +1,9 @@
 pub mod health;
+pub mod http;
 pub mod metrics;
 pub mod metrics_handler;
+pub mod router;
 pub mod server;
+pub mod status;
 pub use metrics::init_metrics;
 pub use server::start_observability_server;

--- a/huginn-ebpf-agent/src/telemetry/router.rs
+++ b/huginn-ebpf-agent/src/telemetry/router.rs
@@ -1,0 +1,19 @@
+use crate::telemetry::http::{json_response, RespBody};
+use crate::telemetry::status::{Status, StatusBody};
+use crate::telemetry::{health, metrics_handler};
+use hyper::{Response, StatusCode};
+use prometheus::Registry;
+use tracing::warn;
+
+pub fn dispatch(path: &str, registry: &Registry, pin_path: &str) -> Response<RespBody> {
+    match path {
+        "/metrics" => metrics_handler::handle_metrics(registry).unwrap_or_else(|e| {
+            warn!(error = %e, "Failed to encode metrics");
+            json_response(StatusCode::INTERNAL_SERVER_ERROR, StatusBody::new(Status::Error))
+        }),
+        "/health" => health::health_check_response(),
+        "/ready" => health::ready_check_response(pin_path),
+        "/live" => health::live_check_response(),
+        _ => json_response(StatusCode::NOT_FOUND, StatusBody::new(Status::NotFound)),
+    }
+}

--- a/huginn-ebpf-agent/src/telemetry/router.rs
+++ b/huginn-ebpf-agent/src/telemetry/router.rs
@@ -3,10 +3,16 @@ use crate::telemetry::status::{Status, StatusBody};
 use crate::telemetry::{health, metrics_handler};
 use hyper::{Response, StatusCode};
 use prometheus::Registry;
-use tracing::warn;
+use tracing::{debug, warn};
 
+/// Route an observability request. Health endpoints are infallible; metrics may fail to
+/// encode and falls back to a JSON 500. Unknown paths return a JSON 404.
+///
+/// Every request is traced at `debug` (path + resulting status); failures that aren't
+/// otherwise visible (not-ready reason, metrics encode error) are logged at `warn` by the
+/// handlers themselves so the cause shows up even at the default log level.
 pub fn dispatch(path: &str, registry: &Registry, pin_path: &str) -> Response<RespBody> {
-    match path {
+    let response = match path {
         "/metrics" => metrics_handler::handle_metrics(registry).unwrap_or_else(|e| {
             warn!(error = %e, "Failed to encode metrics");
             json_response(StatusCode::INTERNAL_SERVER_ERROR, StatusBody::new(Status::Error))
@@ -15,5 +21,8 @@ pub fn dispatch(path: &str, registry: &Registry, pin_path: &str) -> Response<Res
         "/ready" => health::ready_check_response(pin_path),
         "/live" => health::live_check_response(),
         _ => json_response(StatusCode::NOT_FOUND, StatusBody::new(Status::NotFound)),
-    }
+    };
+
+    debug!(path, status = response.status().as_u16(), "Observability request handled");
+    response
 }

--- a/huginn-ebpf-agent/src/telemetry/server.rs
+++ b/huginn-ebpf-agent/src/telemetry/server.rs
@@ -1,10 +1,6 @@
-use crate::telemetry::health;
-use crate::telemetry::metrics_handler;
-use http_body_util::{BodyExt, Full};
-use hyper::body::{Bytes, Incoming};
+use crate::telemetry::router::dispatch;
+use hyper::body::Incoming;
 use hyper::Request;
-use hyper::Response;
-use hyper::StatusCode;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
 use prometheus::Registry;
@@ -17,7 +13,7 @@ pub async fn start_observability_server(
     port: u16,
     registry: Arc<Registry>,
     pin_path: String,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> crate::error::Result<()> {
     let addr = format!("{}:{}", listen_addr, port);
     let listener = TcpListener::bind(&addr).await?;
     info!(%addr, "Observability server started (health, ready, live, metrics)");
@@ -37,69 +33,7 @@ pub async fn start_observability_server(
             let svc = hyper::service::service_fn(move |req: Request<Incoming>| {
                 let registry = registry.clone();
                 let pin_path = pin_path.clone();
-                async move {
-                    let path = req.uri().path();
-                    if path == "/metrics" {
-                        match metrics_handler::handle_metrics(&registry) {
-                            Ok(resp) => Ok::<_, hyper::Error>(resp),
-                            Err(e) => {
-                                warn!(%e, "handle_metrics failed");
-                                let body = Full::new(Bytes::from("Internal Server Error"))
-                                    .map_err(|never| match never {})
-                                    .boxed();
-                                let mut resp = Response::new(body);
-                                *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                Ok(resp)
-                            }
-                        }
-                    } else if path == "/health" {
-                        match health::health_check_response() {
-                            Ok(resp) => Ok::<_, hyper::Error>(resp),
-                            Err(e) => {
-                                warn!(%e, "health_check_response failed");
-                                let body = Full::new(Bytes::from("Internal Server Error"))
-                                    .map_err(|never| match never {})
-                                    .boxed();
-                                let mut resp = Response::new(body);
-                                *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                Ok(resp)
-                            }
-                        }
-                    } else if path == "/ready" {
-                        match health::ready_check_response(&pin_path) {
-                            Ok(resp) => Ok::<_, hyper::Error>(resp),
-                            Err(e) => {
-                                warn!(%e, "ready_check_response failed");
-                                let body = Full::new(Bytes::from("Internal Server Error"))
-                                    .map_err(|never| match never {})
-                                    .boxed();
-                                let mut resp = Response::new(body);
-                                *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                Ok(resp)
-                            }
-                        }
-                    } else if path == "/live" {
-                        match health::live_check_response() {
-                            Ok(resp) => Ok::<_, hyper::Error>(resp),
-                            Err(e) => {
-                                warn!(%e, "live_check_response failed");
-                                let body = Full::new(Bytes::from("Internal Server Error"))
-                                    .map_err(|never| match never {})
-                                    .boxed();
-                                let mut resp = Response::new(body);
-                                *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                Ok(resp)
-                            }
-                        }
-                    } else {
-                        let body = Full::new(Bytes::from("Not Found"))
-                            .map_err(|never| match never {})
-                            .boxed();
-                        let mut resp = Response::new(body);
-                        *resp.status_mut() = StatusCode::NOT_FOUND;
-                        Ok(resp)
-                    }
-                }
+                async move { Ok::<_, hyper::Error>(dispatch(req.uri().path(), &registry, &pin_path)) }
             });
 
             let builder = ConnBuilder::new(TokioExecutor::new());

--- a/huginn-ebpf-agent/src/telemetry/status.rs
+++ b/huginn-ebpf-agent/src/telemetry/status.rs
@@ -1,0 +1,29 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Status {
+    Healthy,
+    Alive,
+    Ready,
+    NotReady,
+    NotFound,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct StatusBody {
+    status: Status,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'static str>,
+}
+
+impl StatusBody {
+    pub(crate) fn new(status: Status) -> Self {
+        Self { status, reason: None }
+    }
+
+    pub(crate) fn with_reason(status: Status, reason: &'static str) -> Self {
+        Self { status, reason: Some(reason) }
+    }
+}

--- a/huginn-proxy-lib/src/lib.rs
+++ b/huginn-proxy-lib/src/lib.rs
@@ -26,4 +26,4 @@ pub use proxy::reload::{
 pub use proxy::server::{SynProbe, WatchOptions};
 pub use proxy::shutdown::{shutdown_channel, ShutdownSender, ShutdownWatch};
 pub use proxy::{forwarding, run};
-pub use telemetry::Metrics;
+pub use telemetry::{Metrics, Readiness};

--- a/huginn-proxy-lib/src/proxy/forwarding.rs
+++ b/huginn-proxy-lib/src/proxy/forwarding.rs
@@ -2,13 +2,12 @@ use crate::config::{BackendHttpVersion, KeepAliveConfig};
 use crate::proxy::http_result::{HttpError, HttpResult};
 use crate::proxy::ClientPool;
 use crate::telemetry::Metrics;
+use crate::utils::http::RespBody;
 use http::{Request, Response, Version};
-use http_body_util::{combinators::BoxBody, BodyExt};
+use http_body_util::BodyExt;
 use hyper::body::Incoming;
 use std::sync::Arc;
 use tokio::time::Instant;
-
-type RespBody = BoxBody<bytes::Bytes, hyper::Error>;
 
 pub struct ForwardConfig<'a> {
     pub backends: &'a [crate::config::Backend],

--- a/huginn-proxy-lib/src/proxy/handler/rate_limit_validation.rs
+++ b/huginn-proxy-lib/src/proxy/handler/rate_limit_validation.rs
@@ -1,5 +1,4 @@
 use http::StatusCode;
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use hyper::Response;
 use ipnet::IpNet;
 use std::sync::Arc;
@@ -9,8 +8,7 @@ use crate::config::RateLimitConfig;
 use crate::proxy::router::RouteMatch;
 use crate::security::{extract_rate_limit_key, RateLimitManager, RateLimitResult};
 use crate::telemetry::Metrics;
-
-type RespBody = BoxBody<bytes::Bytes, hyper::Error>;
+use crate::utils::http::{text_response, RespBody};
 
 /// Check rate limiting for incoming request.
 ///
@@ -66,11 +64,7 @@ pub fn check_rate_limit(
 }
 
 fn create_429_response(limit: isize, reset_after_secs: u64) -> Response<RespBody> {
-    let body = Full::new(bytes::Bytes::from("Too Many Requests"))
-        .map_err(|never| match never {})
-        .boxed();
-    let mut resp = Response::new(body);
-    *resp.status_mut() = StatusCode::TOO_MANY_REQUESTS;
+    let mut resp = text_response(StatusCode::TOO_MANY_REQUESTS, "Too Many Requests");
 
     resp.headers_mut().insert(
         hyper::header::HeaderName::from_static("x-rate-limit-limit"),

--- a/huginn-proxy-lib/src/proxy/handler/rate_limit_validation.rs
+++ b/huginn-proxy-lib/src/proxy/handler/rate_limit_validation.rs
@@ -8,7 +8,7 @@ use crate::config::RateLimitConfig;
 use crate::proxy::router::RouteMatch;
 use crate::security::{extract_rate_limit_key, RateLimitManager, RateLimitResult};
 use crate::telemetry::Metrics;
-use crate::utils::http::{text_response, RespBody};
+use crate::utils::http::{json_error, RespBody};
 
 /// Check rate limiting for incoming request.
 ///
@@ -64,7 +64,7 @@ pub fn check_rate_limit(
 }
 
 fn create_429_response(limit: isize, reset_after_secs: u64) -> Response<RespBody> {
-    let mut resp = text_response(StatusCode::TOO_MANY_REQUESTS, "Too Many Requests");
+    let mut resp = json_error(StatusCode::TOO_MANY_REQUESTS, "too_many_requests");
 
     resp.headers_mut().insert(
         hyper::header::HeaderName::from_static("x-rate-limit-limit"),

--- a/huginn-proxy-lib/src/proxy/handler/request.rs
+++ b/huginn-proxy-lib/src/proxy/handler/request.rs
@@ -25,7 +25,7 @@ use tokio::sync::watch;
 use tokio::time::Instant;
 use tracing::debug;
 
-type RespBody = http_body_util::combinators::BoxBody<bytes::Bytes, hyper::Error>;
+use crate::utils::http::RespBody;
 
 /// Strip all proxy-authoritative fingerprint headers from an incoming request.
 ///

--- a/huginn-proxy-lib/src/proxy/server.rs
+++ b/huginn-proxy-lib/src/proxy/server.rs
@@ -12,7 +12,7 @@ use crate::proxy::reload::{
 };
 use crate::proxy::shutdown::{wait_for_drain, ServiceHandle, ShutdownSender};
 pub use crate::proxy::watch::WatchOptions;
-use crate::telemetry::Metrics;
+use crate::telemetry::{Metrics, Readiness};
 use crate::tls::{build_tls_acceptor, DynamicCertResolver};
 use hyper_util::rt::{TokioExecutor, TokioTimer};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
@@ -33,6 +33,7 @@ pub async fn run(
     syn_probe: Option<SynProbe>,
     watch_opts: WatchOptions,
     shutdown_tx: ShutdownSender,
+    readiness: Readiness,
 ) -> Result<()> {
     // Derive receiver from the sender so all clones share the same channel
     let shutdown_rx = shutdown_tx.subscribe();
@@ -175,6 +176,9 @@ pub async fn run(
         ));
     }
 
+    readiness.mark_ready();
+    info!("Proxy ready: accepting connections");
+
     // Signal loop: SIGHUP forwards to the reload channel; SIGTERM/SIGINT trigger shutdown.
     loop {
         tokio::select! {
@@ -204,6 +208,7 @@ pub async fn run(
             }
             _ = sigterm.recv() => {
                 info!("Received SIGTERM, initiating graceful shutdown");
+                readiness.mark_not_ready();
                 health_supervisor.shutdown();
                 shutdown_signal.store(1, Ordering::Relaxed);
                 shutdown_tx.send(true).ok();
@@ -211,6 +216,7 @@ pub async fn run(
             }
             _ = sigint.recv() => {
                 info!("Received SIGINT, initiating graceful shutdown");
+                readiness.mark_not_ready();
                 health_supervisor.shutdown();
                 shutdown_signal.store(1, Ordering::Relaxed);
                 shutdown_tx.send(true).ok();

--- a/huginn-proxy-lib/src/proxy/synthetic_response.rs
+++ b/huginn-proxy-lib/src/proxy/synthetic_response.rs
@@ -1,10 +1,7 @@
 use crate::error::{ProxyError, ProxyResult};
+use crate::utils::http::{empty_body, RespBody};
 use http::StatusCode;
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
-use hyper::body::Bytes;
 use hyper::Response;
-
-type RespBody = BoxBody<Bytes, hyper::Error>;
 
 /// Build HTTP response with status code of 4xx and 5xx
 pub(crate) fn synthetic_error_response(status_code: StatusCode) -> ProxyResult<Response<RespBody>> {
@@ -13,10 +10,4 @@ pub(crate) fn synthetic_error_response(status_code: StatusCode) -> ProxyResult<R
         .body(empty_body())
         .map_err(|e| ProxyError::Http(format!("Failed to build error response: {e}")))?;
     Ok(res)
-}
-
-fn empty_body() -> RespBody {
-    Full::new(Bytes::new())
-        .map_err(|never| match never {})
-        .boxed()
 }

--- a/huginn-proxy-lib/src/proxy/transport/plain.rs
+++ b/huginn-proxy-lib/src/proxy/transport/plain.rs
@@ -82,9 +82,9 @@ pub async fn handle_plain_connection(
                     metrics_for_match.record_error(e.error_type());
                     match synthetic_error_response(code) {
                         Ok(resp) => Ok(resp),
-                        Err(e) => Ok(crate::utils::http::text_response(
+                        Err(e) => Ok(crate::utils::http::json_error(
                             StatusCode::INTERNAL_SERVER_ERROR,
-                            format!("Failed to create error response: {e}"),
+                            &format!("Failed to create error response: {e}"),
                         )),
                     }
                 }

--- a/huginn-proxy-lib/src/proxy/transport/plain.rs
+++ b/huginn-proxy-lib/src/proxy/transport/plain.rs
@@ -8,7 +8,6 @@ use crate::proxy::synthetic_response::synthetic_error_response;
 use crate::proxy::ClientPool;
 use crate::telemetry::Metrics;
 use http::StatusCode;
-use http_body_util::BodyExt;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
 use tokio::net::TcpStream;
@@ -83,16 +82,10 @@ pub async fn handle_plain_connection(
                     metrics_for_match.record_error(e.error_type());
                     match synthetic_error_response(code) {
                         Ok(resp) => Ok(resp),
-                        Err(e) => {
-                            let body = http_body_util::Full::new(bytes::Bytes::from(format!(
-                                "Failed to create error response: {e}"
-                            )))
-                            .map_err(|never| match never {})
-                            .boxed();
-                            let mut resp = hyper::Response::new(body);
-                            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                            Ok(resp)
-                        }
+                        Err(e) => Ok(crate::utils::http::text_response(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Failed to create error response: {e}"),
+                        )),
                     }
                 }
             }

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -12,7 +12,6 @@ use crate::telemetry::Metrics;
 use crate::tls::record_tls_handshake_metrics;
 use crate::tls::setup::SharedTlsAcceptor;
 use http::StatusCode;
-use http_body_util::BodyExt;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
 use tokio::net::TcpStream;
@@ -161,16 +160,10 @@ pub async fn handle_tls_connection(
                                 metrics_for_match.record_error(e.error_type());
                                 match synthetic_error_response(code) {
                                     Ok(resp) => Ok(resp),
-                                    Err(e) => {
-                                        let body = http_body_util::Full::new(bytes::Bytes::from(
-                                            format!("Failed to create error response: {e}"),
-                                        ))
-                                        .map_err(|never| match never {})
-                                        .boxed();
-                                        let mut resp = hyper::Response::new(body);
-                                        *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                        Ok(resp)
-                                    }
+                                    Err(e) => Ok(crate::utils::http::text_response(
+                                        StatusCode::INTERNAL_SERVER_ERROR,
+                                        format!("Failed to create error response: {e}"),
+                                    )),
                                 }
                             }
                         }
@@ -234,16 +227,10 @@ pub async fn handle_tls_connection(
                                 metrics_for_match.record_error(e.error_type());
                                 match synthetic_error_response(code) {
                                     Ok(resp) => Ok(resp),
-                                    Err(e) => {
-                                        let body = http_body_util::Full::new(bytes::Bytes::from(
-                                            format!("Failed to create error response: {e}"),
-                                        ))
-                                        .map_err(|never| match never {})
-                                        .boxed();
-                                        let mut resp = hyper::Response::new(body);
-                                        *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                                        Ok(resp)
-                                    }
+                                    Err(e) => Ok(crate::utils::http::text_response(
+                                        StatusCode::INTERNAL_SERVER_ERROR,
+                                        format!("Failed to create error response: {e}"),
+                                    )),
                                 }
                             }
                         }

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -160,9 +160,9 @@ pub async fn handle_tls_connection(
                                 metrics_for_match.record_error(e.error_type());
                                 match synthetic_error_response(code) {
                                     Ok(resp) => Ok(resp),
-                                    Err(e) => Ok(crate::utils::http::text_response(
+                                    Err(e) => Ok(crate::utils::http::json_error(
                                         StatusCode::INTERNAL_SERVER_ERROR,
-                                        format!("Failed to create error response: {e}"),
+                                        &format!("Failed to create error response: {e}"),
                                     )),
                                 }
                             }
@@ -227,9 +227,9 @@ pub async fn handle_tls_connection(
                                 metrics_for_match.record_error(e.error_type());
                                 match synthetic_error_response(code) {
                                     Ok(resp) => Ok(resp),
-                                    Err(e) => Ok(crate::utils::http::text_response(
+                                    Err(e) => Ok(crate::utils::http::json_error(
                                         StatusCode::INTERNAL_SERVER_ERROR,
-                                        format!("Failed to create error response: {e}"),
+                                        &format!("Failed to create error response: {e}"),
                                     )),
                                 }
                             }

--- a/huginn-proxy-lib/src/telemetry/health.rs
+++ b/huginn-proxy-lib/src/telemetry/health.rs
@@ -1,34 +1,18 @@
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
-use hyper::body::Bytes;
 use hyper::Response;
 use hyper::StatusCode;
-use serde_json::json;
 use tracing::warn;
 
-use crate::error::Result;
+use crate::telemetry::status::{Status, StatusBody};
+use crate::utils::http::{json_response, RespBody};
 
-type RespBody = BoxBody<Bytes, hyper::Error>;
+/// Health check - always 200 while the process is running.
+pub fn health_check_response() -> Response<RespBody> {
+    json_response(StatusCode::OK, StatusBody::new(Status::Healthy))
+}
 
-/// Health check response - always returns 200 if process is running
-pub fn health_check_response() -> Result<Response<RespBody>> {
-    let body = json!({"status": "healthy"});
-    let body_bytes = serde_json::to_vec(&body).map_err(|e| {
-        crate::error::ProxyError::Http(format!("Failed to serialize health response: {e}"))
-    })?;
-
-    let body = Full::new(Bytes::from(body_bytes))
-        .map_err(|never| match never {})
-        .boxed();
-
-    let response = Response::builder()
-        .status(StatusCode::OK)
-        .header("Content-Type", "application/json")
-        .body(body)
-        .map_err(|e| {
-            crate::error::ProxyError::Http(format!("Failed to build health response: {e}"))
-        })?;
-
-    Ok(response)
+/// Liveness check - always 200 while the process is running.
+pub fn live_check_response() -> Response<RespBody> {
+    json_response(StatusCode::OK, StatusBody::new(Status::Alive))
 }
 
 /// Readiness check - reports whether the proxy has finished starting up and is
@@ -41,72 +25,15 @@ pub fn health_check_response() -> Result<Response<RespBody>> {
 ///
 /// `ready` is `false` while the listeners are still binding/initialising and during
 /// graceful shutdown; `true` once the proxy is accepting connections.
-pub fn ready_check_response(ready: bool) -> Result<Response<RespBody>> {
-    if !ready {
-        let reason = "proxy_starting";
-        warn!(reason, "Readiness check failed: proxy is not accepting connections yet");
-
-        let body = json!({
-            "status": "not_ready",
-            "reason": reason
-        });
-        let body_bytes = serde_json::to_vec(&body).map_err(|e| {
-            crate::error::ProxyError::Http(format!("Failed to serialize ready response: {e}"))
-        })?;
-
-        let body = Full::new(Bytes::from(body_bytes))
-            .map_err(|never| match never {})
-            .boxed();
-
-        let response = Response::builder()
-            .status(StatusCode::SERVICE_UNAVAILABLE)
-            .header("Content-Type", "application/json")
-            .body(body)
-            .map_err(|e| {
-                crate::error::ProxyError::Http(format!("Failed to build ready response: {e}"))
-            })?;
-
-        Ok(response)
-    } else {
-        let body = json!({"status": "ready"});
-        let body_bytes = serde_json::to_vec(&body).map_err(|e| {
-            crate::error::ProxyError::Http(format!("Failed to serialize ready response: {e}"))
-        })?;
-
-        let body = Full::new(Bytes::from(body_bytes))
-            .map_err(|never| match never {})
-            .boxed();
-
-        let response = Response::builder()
-            .status(StatusCode::OK)
-            .header("Content-Type", "application/json")
-            .body(body)
-            .map_err(|e| {
-                crate::error::ProxyError::Http(format!("Failed to build ready response: {e}"))
-            })?;
-
-        Ok(response)
+pub fn ready_check_response(ready: bool) -> Response<RespBody> {
+    if ready {
+        return json_response(StatusCode::OK, StatusBody::new(Status::Ready));
     }
-}
 
-/// Liveness check - always returns 200 if process is running
-pub fn live_check_response() -> Result<Response<RespBody>> {
-    let body = json!({"status": "alive"});
-    let body_bytes = serde_json::to_vec(&body).map_err(|e| {
-        crate::error::ProxyError::Http(format!("Failed to serialize live response: {e}"))
-    })?;
-
-    let body = Full::new(Bytes::from(body_bytes))
-        .map_err(|never| match never {})
-        .boxed();
-
-    let response = Response::builder()
-        .status(StatusCode::OK)
-        .header("Content-Type", "application/json")
-        .body(body)
-        .map_err(|e| {
-            crate::error::ProxyError::Http(format!("Failed to build live response: {e}"))
-        })?;
-
-    Ok(response)
+    let reason = "proxy_starting";
+    warn!(reason, "Readiness check failed: proxy is not accepting connections yet");
+    json_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        StatusBody::with_reason(Status::NotReady, reason),
+    )
 }

--- a/huginn-proxy-lib/src/telemetry/health.rs
+++ b/huginn-proxy-lib/src/telemetry/health.rs
@@ -3,8 +3,8 @@ use hyper::body::Bytes;
 use hyper::Response;
 use hyper::StatusCode;
 use serde_json::json;
+use tracing::warn;
 
-use crate::config::Backend;
 use crate::error::Result;
 
 type RespBody = BoxBody<Bytes, hyper::Error>;
@@ -31,13 +31,24 @@ pub fn health_check_response() -> Result<Response<RespBody>> {
     Ok(response)
 }
 
-/// Readiness check - verifies that backends are available
-/// Returns 200 if at least one backend is configured, 503 otherwise
-pub fn ready_check_response(backends: &[Backend]) -> Result<Response<RespBody>> {
-    if backends.is_empty() {
+/// Readiness check - reports whether the proxy has finished starting up and is
+/// accepting connections.
+///
+/// Decoupled from backend availability on purpose: a proxy can serve traffic even when
+/// every backend is down (that surfaces as 502s on real requests plus backend-health
+/// metrics, not as readiness). Tying readiness to backends would keep the pod out of
+/// rotation forever when backends are registered dynamically. This mirrors Traefik/Envoy.
+///
+/// `ready` is `false` while the listeners are still binding/initialising and during
+/// graceful shutdown; `true` once the proxy is accepting connections.
+pub fn ready_check_response(ready: bool) -> Result<Response<RespBody>> {
+    if !ready {
+        let reason = "proxy_starting";
+        warn!(reason, "Readiness check failed: proxy is not accepting connections yet");
+
         let body = json!({
             "status": "not_ready",
-            "reason": "no_backends_configured"
+            "reason": reason
         });
         let body_bytes = serde_json::to_vec(&body).map_err(|e| {
             crate::error::ProxyError::Http(format!("Failed to serialize ready response: {e}"))

--- a/huginn-proxy-lib/src/telemetry/health.rs
+++ b/huginn-proxy-lib/src/telemetry/health.rs
@@ -17,12 +17,6 @@ pub fn live_check_response() -> Response<RespBody> {
 
 /// Readiness check - reports whether the proxy has finished starting up and is
 /// accepting connections.
-///
-/// Decoupled from backend availability on purpose: a proxy can serve traffic even when
-/// every backend is down (that surfaces as 502s on real requests plus backend-health
-/// metrics, not as readiness). Tying readiness to backends would keep the pod out of
-/// rotation forever when backends are registered dynamically. This mirrors Traefik/Envoy.
-///
 /// `ready` is `false` while the listeners are still binding/initialising and during
 /// graceful shutdown; `true` once the proxy is accepting connections.
 pub fn ready_check_response(ready: bool) -> Response<RespBody> {

--- a/huginn-proxy-lib/src/telemetry/metrics_handler.rs
+++ b/huginn-proxy-lib/src/telemetry/metrics_handler.rs
@@ -1,12 +1,9 @@
-use http_body_util::{combinators::BoxBody, BodyExt, Full};
-use hyper::body::Bytes;
 use hyper::Response;
 use hyper::StatusCode;
 use prometheus::{Encoder, TextEncoder};
 
 use crate::error::Result;
-
-type RespBody = BoxBody<Bytes, hyper::Error>;
+use crate::utils::http::{full_body, RespBody};
 
 pub fn handle_metrics(registry: &prometheus::Registry) -> Result<Response<RespBody>> {
     let encoder = TextEncoder::new();
@@ -17,15 +14,9 @@ pub fn handle_metrics(registry: &prometheus::Registry) -> Result<Response<RespBo
         .encode(&metric_families, &mut buffer)
         .map_err(|e| crate::error::ProxyError::Http(format!("Failed to encode metrics: {e}")))?;
 
-    let body = Full::new(Bytes::from(buffer))
-        .map_err(|never| match never {})
-        .boxed();
-
-    let response = Response::builder()
+    Response::builder()
         .status(StatusCode::OK)
         .header("Content-Type", encoder.format_type())
-        .body(body)
-        .map_err(|e| crate::error::ProxyError::Http(format!("Failed to build response: {e}")))?;
-
-    Ok(response)
+        .body(full_body(buffer))
+        .map_err(|e| crate::error::ProxyError::Http(format!("Failed to build response: {e}")))
 }

--- a/huginn-proxy-lib/src/telemetry/mod.rs
+++ b/huginn-proxy-lib/src/telemetry/mod.rs
@@ -4,6 +4,7 @@ pub mod metrics_handler;
 pub mod readiness;
 pub mod router;
 pub mod server;
+pub mod status;
 pub mod tracing;
 
 pub use health::{health_check_response, live_check_response, ready_check_response};

--- a/huginn-proxy-lib/src/telemetry/mod.rs
+++ b/huginn-proxy-lib/src/telemetry/mod.rs
@@ -1,11 +1,14 @@
 pub mod health;
 pub mod metrics;
 pub mod metrics_handler;
+pub mod readiness;
+pub mod router;
 pub mod server;
 pub mod tracing;
 
 pub use health::{health_check_response, live_check_response, ready_check_response};
 pub use metrics::{init_metrics, values, Metrics};
 pub use metrics_handler::handle_metrics;
+pub use readiness::Readiness;
 pub use server::start_observability_server;
 pub use tracing::{init_tracing_with_otel, shutdown_tracing};

--- a/huginn-proxy-lib/src/telemetry/readiness.rs
+++ b/huginn-proxy-lib/src/telemetry/readiness.rs
@@ -1,0 +1,36 @@
+//! Readiness state shared between the proxy and the observability server's `/ready`
+//! endpoint.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Tracks whether the proxy is ready to accept traffic.
+///
+/// Cheaply cloneable (shared `Arc`). The proxy flips it ready once its listeners are
+/// accepting connections and back to not-ready during graceful shutdown; the `/ready`
+/// endpoint reads it. Readiness reflects internal process state only and is deliberately
+/// independent of backend availability.
+#[derive(Clone, Default)]
+pub struct Readiness(Arc<AtomicBool>);
+
+impl Readiness {
+    /// Create a new handle in the not-ready state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark the proxy as ready to accept traffic (`/ready` -> 200).
+    pub fn mark_ready(&self) {
+        self.0.store(true, Ordering::Release);
+    }
+
+    /// Mark the proxy as not ready (`/ready` -> 503), e.g. during graceful shutdown.
+    pub fn mark_not_ready(&self) {
+        self.0.store(false, Ordering::Release);
+    }
+
+    /// Whether the proxy is currently ready to accept traffic.
+    pub fn is_ready(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
+}

--- a/huginn-proxy-lib/src/telemetry/readiness.rs
+++ b/huginn-proxy-lib/src/telemetry/readiness.rs
@@ -1,15 +1,8 @@
-//! Readiness state shared between the proxy and the observability server's `/ready`
-//! endpoint.
+//! Readiness state shared between the proxy and the observability server's `/ready` endpoint.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-/// Tracks whether the proxy is ready to accept traffic.
-///
-/// Cheaply cloneable (shared `Arc`). The proxy flips it ready once its listeners are
-/// accepting connections and back to not-ready during graceful shutdown; the `/ready`
-/// endpoint reads it. Readiness reflects internal process state only and is deliberately
-/// independent of backend availability.
 #[derive(Clone, Default)]
 pub struct Readiness(Arc<AtomicBool>);
 

--- a/huginn-proxy-lib/src/telemetry/router.rs
+++ b/huginn-proxy-lib/src/telemetry/router.rs
@@ -1,41 +1,27 @@
 //! HTTP routing for the observability server: maps a request path to the matching
-//! health/metrics handler and centralises the 404 / 500 fallbacks.
+//! health/metrics handler and centralises the JSON 404 / 500 fallbacks.
 
-use http_body_util::combinators::BoxBody;
-use http_body_util::{BodyExt, Full};
-use hyper::body::Bytes;
 use hyper::{Response, StatusCode};
 use prometheus::Registry;
 use tracing::warn;
 
+use crate::telemetry::status::{Status, StatusBody};
 use crate::telemetry::{
     handle_metrics, health_check_response, live_check_response, ready_check_response, Readiness,
 };
+use crate::utils::http::{json_response, RespBody};
 
-pub type RespBody = BoxBody<Bytes, hyper::Error>;
-
-/// Build a plain-text response with the given status (used for 404 and 500).
-fn status_response(status: StatusCode, message: &'static str) -> Response<RespBody> {
-    let body = Full::new(Bytes::from(message))
-        .map_err(|never| match never {})
-        .boxed();
-    let mut resp = Response::new(body);
-    *resp.status_mut() = status;
-    resp
-}
-
-/// Route an observability request, collapsing the per-endpoint 500 handling into one place.
+/// Route an observability request. Health endpoints are infallible; metrics may fail to
+/// encode and falls back to a JSON 500. Unknown paths return a JSON 404.
 pub fn dispatch(path: &str, registry: &Registry, readiness: &Readiness) -> Response<RespBody> {
-    let result = match path {
+    match path {
         "/health" => health_check_response(),
         "/ready" => ready_check_response(readiness.is_ready()),
         "/live" => live_check_response(),
-        "/metrics" => handle_metrics(registry),
-        _ => return status_response(StatusCode::NOT_FOUND, "Not Found"),
-    };
-
-    result.unwrap_or_else(|e| {
-        warn!(path, error = %e, "Observability handler failed to build response");
-        status_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")
-    })
+        "/metrics" => handle_metrics(registry).unwrap_or_else(|e| {
+            warn!(error = %e, "Failed to encode metrics");
+            json_response(StatusCode::INTERNAL_SERVER_ERROR, StatusBody::new(Status::Error))
+        }),
+        _ => json_response(StatusCode::NOT_FOUND, StatusBody::new(Status::NotFound)),
+    }
 }

--- a/huginn-proxy-lib/src/telemetry/router.rs
+++ b/huginn-proxy-lib/src/telemetry/router.rs
@@ -1,0 +1,41 @@
+//! HTTP routing for the observability server: maps a request path to the matching
+//! health/metrics handler and centralises the 404 / 500 fallbacks.
+
+use http_body_util::combinators::BoxBody;
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::{Response, StatusCode};
+use prometheus::Registry;
+use tracing::warn;
+
+use crate::telemetry::{
+    handle_metrics, health_check_response, live_check_response, ready_check_response, Readiness,
+};
+
+pub type RespBody = BoxBody<Bytes, hyper::Error>;
+
+/// Build a plain-text response with the given status (used for 404 and 500).
+fn status_response(status: StatusCode, message: &'static str) -> Response<RespBody> {
+    let body = Full::new(Bytes::from(message))
+        .map_err(|never| match never {})
+        .boxed();
+    let mut resp = Response::new(body);
+    *resp.status_mut() = status;
+    resp
+}
+
+/// Route an observability request, collapsing the per-endpoint 500 handling into one place.
+pub fn dispatch(path: &str, registry: &Registry, readiness: &Readiness) -> Response<RespBody> {
+    let result = match path {
+        "/health" => health_check_response(),
+        "/ready" => ready_check_response(readiness.is_ready()),
+        "/live" => live_check_response(),
+        "/metrics" => handle_metrics(registry),
+        _ => return status_response(StatusCode::NOT_FOUND, "Not Found"),
+    };
+
+    result.unwrap_or_else(|e| {
+        warn!(path, error = %e, "Observability handler failed to build response");
+        status_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")
+    })
+}

--- a/huginn-proxy-lib/src/telemetry/router.rs
+++ b/huginn-proxy-lib/src/telemetry/router.rs
@@ -1,9 +1,6 @@
-//! HTTP routing for the observability server: maps a request path to the matching
-//! health/metrics handler and centralises the JSON 404 / 500 fallbacks.
-
 use hyper::{Response, StatusCode};
 use prometheus::Registry;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::telemetry::status::{Status, StatusBody};
 use crate::telemetry::{
@@ -11,10 +8,8 @@ use crate::telemetry::{
 };
 use crate::utils::http::{json_response, RespBody};
 
-/// Route an observability request. Health endpoints are infallible; metrics may fail to
-/// encode and falls back to a JSON 500. Unknown paths return a JSON 404.
 pub fn dispatch(path: &str, registry: &Registry, readiness: &Readiness) -> Response<RespBody> {
-    match path {
+    let response = match path {
         "/health" => health_check_response(),
         "/ready" => ready_check_response(readiness.is_ready()),
         "/live" => live_check_response(),
@@ -23,5 +18,8 @@ pub fn dispatch(path: &str, registry: &Registry, readiness: &Readiness) -> Respo
             json_response(StatusCode::INTERNAL_SERVER_ERROR, StatusBody::new(Status::Error))
         }),
         _ => json_response(StatusCode::NOT_FOUND, StatusBody::new(Status::NotFound)),
-    }
+    };
+
+    debug!(path, status = response.status().as_u16(), "Observability request handled");
+    response
 }

--- a/huginn-proxy-lib/src/telemetry/server.rs
+++ b/huginn-proxy-lib/src/telemetry/server.rs
@@ -1,9 +1,6 @@
-use crate::config::Backend;
-use crate::telemetry::{
-    handle_metrics, health_check_response, live_check_response, ready_check_response,
-};
-use http_body_util::{BodyExt, Full};
-use hyper::body::{Bytes, Incoming};
+use crate::telemetry::router::dispatch;
+use crate::telemetry::Readiness;
+use hyper::body::Incoming;
 use hyper::Request;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
@@ -20,10 +17,13 @@ use tracing::{info, warn};
 /// - `/health` - Health check endpoint
 /// - `/ready` - Readiness check endpoint
 /// - `/live` - Liveness check endpoint
+///
+/// `readiness` is flipped to `true` by the proxy once its listeners are accepting
+/// connections and back to `false` during graceful shutdown; `/ready` reflects it.
 pub async fn start_observability_server(
     port: u16,
     registry: Registry,
-    backends: Arc<Vec<Backend>>,
+    readiness: Readiness,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let registry = Arc::new(registry);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -56,70 +56,17 @@ pub async fn start_observability_server(
                 };
 
                 let registry = registry.clone();
-                let backends = backends.clone();
+                let readiness = readiness.clone();
                 tokio::spawn(async move {
                     let svc = hyper::service::service_fn(move |req: Request<Incoming>| {
                         let registry = registry.clone();
-                        let backends = backends.clone();
+                        let readiness = readiness.clone();
                         async move {
-                            let path = req.uri().path();
-
-                            if path == "/health" {
-                                match health_check_response() {
-                                    Ok(resp) => Ok::<_, hyper::Error>(resp),
-                                    Err(_) => {
-                                        let body = Full::new(Bytes::from("Internal Server Error"))
-                                            .map_err(|never| match never {})
-                                            .boxed();
-                                        let mut resp = hyper::Response::new(body);
-                                        *resp.status_mut() = hyper::StatusCode::INTERNAL_SERVER_ERROR;
-                                        Ok(resp)
-                                    }
-                                }
-                            } else if path == "/ready" {
-                                match ready_check_response(&backends) {
-                                    Ok(resp) => Ok::<_, hyper::Error>(resp),
-                                    Err(_) => {
-                                        let body = Full::new(Bytes::from("Internal Server Error"))
-                                            .map_err(|never| match never {})
-                                            .boxed();
-                                        let mut resp = hyper::Response::new(body);
-                                        *resp.status_mut() = hyper::StatusCode::INTERNAL_SERVER_ERROR;
-                                        Ok(resp)
-                                    }
-                                }
-                            } else if path == "/live" {
-                                match live_check_response() {
-                                    Ok(resp) => Ok::<_, hyper::Error>(resp),
-                                    Err(_) => {
-                                        let body = Full::new(Bytes::from("Internal Server Error"))
-                                            .map_err(|never| match never {})
-                                            .boxed();
-                                        let mut resp = hyper::Response::new(body);
-                                        *resp.status_mut() = hyper::StatusCode::INTERNAL_SERVER_ERROR;
-                                        Ok(resp)
-                                    }
-                                }
-                            } else if path == "/metrics" {
-                                match handle_metrics(&registry) {
-                                    Ok(resp) => Ok::<_, hyper::Error>(resp),
-                                    Err(_) => {
-                                        let body = Full::new(Bytes::from("Internal Server Error"))
-                                            .map_err(|never| match never {})
-                                            .boxed();
-                                        let mut resp = hyper::Response::new(body);
-                                        *resp.status_mut() = hyper::StatusCode::INTERNAL_SERVER_ERROR;
-                                        Ok(resp)
-                                    }
-                                }
-                            } else {
-                                let body = Full::new(Bytes::from("Not Found"))
-                                    .map_err(|never| match never {})
-                                    .boxed();
-                                let mut resp = hyper::Response::new(body);
-                                *resp.status_mut() = hyper::StatusCode::NOT_FOUND;
-                                Ok(resp)
-                            }
+                            Ok::<_, hyper::Error>(dispatch(
+                                req.uri().path(),
+                                &registry,
+                                &readiness,
+                            ))
                         }
                     });
 

--- a/huginn-proxy-lib/src/telemetry/status.rs
+++ b/huginn-proxy-lib/src/telemetry/status.rs
@@ -1,0 +1,30 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Status {
+    Healthy,
+    Alive,
+    Ready,
+    NotReady,
+    NotFound,
+    Error,
+}
+
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct StatusBody {
+    status: Status,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'static str>,
+}
+
+impl StatusBody {
+    pub(crate) fn new(status: Status) -> Self {
+        Self { status, reason: None }
+    }
+
+    pub(crate) fn with_reason(status: Status, reason: &'static str) -> Self {
+        Self { status, reason: Some(reason) }
+    }
+}

--- a/huginn-proxy-lib/src/telemetry/status.rs
+++ b/huginn-proxy-lib/src/telemetry/status.rs
@@ -11,7 +11,6 @@ pub(crate) enum Status {
     Error,
 }
 
-
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct StatusBody {
     status: Status,

--- a/huginn-proxy-lib/src/utils/http.rs
+++ b/huginn-proxy-lib/src/utils/http.rs
@@ -1,39 +1,21 @@
-//! Shared helpers for building boxed HTTP response bodies and simple responses.
-//!
-//! Centralises the `BoxBody<Bytes, hyper::Error>` alias and the `Full` boxing dance
-//! (`Full` is infallible, so its `Infallible` error is mapped away) that would otherwise
-//! be duplicated across every module that produces a response.
-
 use http_body_util::{combinators::BoxBody, BodyExt, Full};
 use hyper::body::Bytes;
 use hyper::header::{HeaderValue, CONTENT_TYPE};
 use hyper::{Response, StatusCode};
 use serde::Serialize;
 
-/// Boxed response body shared by the proxy and the observability server.
 pub(crate) type RespBody = BoxBody<Bytes, hyper::Error>;
 
-/// Box a fixed byte buffer into a [`RespBody`].
 pub(crate) fn full_body(bytes: impl Into<Bytes>) -> RespBody {
     Full::new(bytes.into())
         .map_err(|never| match never {})
         .boxed()
 }
 
-/// An empty boxed body.
 pub(crate) fn empty_body() -> RespBody {
     full_body(Bytes::new())
 }
 
-/// Build a plain-text response with the given status. Used for responses on the proxy
-/// data path (e.g. 429 / 5xx returned to real clients).
-pub(crate) fn text_response(status: StatusCode, message: impl Into<Bytes>) -> Response<RespBody> {
-    let mut resp = Response::new(full_body(message));
-    *resp.status_mut() = status;
-    resp
-}
-
-/// Build an `application/json` response with the given status.
 pub(crate) fn json_response(status: StatusCode, body: impl Serialize) -> Response<RespBody> {
     let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
     let mut resp = Response::new(full_body(bytes));
@@ -41,4 +23,13 @@ pub(crate) fn json_response(status: StatusCode, body: impl Serialize) -> Respons
     resp.headers_mut()
         .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
     resp
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    error: &'a str,
+}
+
+pub(crate) fn json_error(status: StatusCode, error: &str) -> Response<RespBody> {
+    json_response(status, ErrorBody { error })
 }

--- a/huginn-proxy-lib/src/utils/http.rs
+++ b/huginn-proxy-lib/src/utils/http.rs
@@ -1,0 +1,44 @@
+//! Shared helpers for building boxed HTTP response bodies and simple responses.
+//!
+//! Centralises the `BoxBody<Bytes, hyper::Error>` alias and the `Full` boxing dance
+//! (`Full` is infallible, so its `Infallible` error is mapped away) that would otherwise
+//! be duplicated across every module that produces a response.
+
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use hyper::body::Bytes;
+use hyper::header::{HeaderValue, CONTENT_TYPE};
+use hyper::{Response, StatusCode};
+use serde::Serialize;
+
+/// Boxed response body shared by the proxy and the observability server.
+pub(crate) type RespBody = BoxBody<Bytes, hyper::Error>;
+
+/// Box a fixed byte buffer into a [`RespBody`].
+pub(crate) fn full_body(bytes: impl Into<Bytes>) -> RespBody {
+    Full::new(bytes.into())
+        .map_err(|never| match never {})
+        .boxed()
+}
+
+/// An empty boxed body.
+pub(crate) fn empty_body() -> RespBody {
+    full_body(Bytes::new())
+}
+
+/// Build a plain-text response with the given status. Used for responses on the proxy
+/// data path (e.g. 429 / 5xx returned to real clients).
+pub(crate) fn text_response(status: StatusCode, message: impl Into<Bytes>) -> Response<RespBody> {
+    let mut resp = Response::new(full_body(message));
+    *resp.status_mut() = status;
+    resp
+}
+
+/// Build an `application/json` response with the given status.
+pub(crate) fn json_response(status: StatusCode, body: impl Serialize) -> Response<RespBody> {
+    let bytes = serde_json::to_vec(&body).unwrap_or_else(|_| b"{}".to_vec());
+    let mut resp = Response::new(full_body(bytes));
+    *resp.status_mut() = status;
+    resp.headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    resp
+}

--- a/huginn-proxy-lib/src/utils/mod.rs
+++ b/huginn-proxy-lib/src/utils/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod http;
+
 use tokio::time::{Duration, Instant};
 
 /// Returns `base + duration`, falling back gracefully if the addition overflows.

--- a/huginn-proxy-lib/tests/capture_fixtures.rs
+++ b/huginn-proxy-lib/tests/capture_fixtures.rs
@@ -252,6 +252,7 @@ async fn capture_fingerprint_values() -> Result<(), Box<dyn std::error::Error + 
             None,
             huginn_proxy_lib::WatchOptions::default(),
             shutdown_tx,
+            huginn_proxy_lib::Readiness::new(),
         )
         .await;
     });

--- a/huginn-proxy-lib/tests/hot_reload/helpers.rs
+++ b/huginn-proxy-lib/tests/hot_reload/helpers.rs
@@ -137,6 +137,7 @@ pub async fn spawn_proxy(
             None,
             WatchOptions { config_path: Some(config_path_buf), watch, watch_delay_secs },
             shutdown_tx,
+            huginn_proxy_lib::Readiness::new(),
         )
         .await;
     });

--- a/huginn-proxy/src/main.rs
+++ b/huginn-proxy/src/main.rs
@@ -10,7 +10,7 @@ use huginn_proxy_lib::config::load_from_path;
 use huginn_proxy_lib::proxy::shutdown::{shutdown_channel, ServiceHandle, ServiceName};
 use huginn_proxy_lib::run;
 use huginn_proxy_lib::telemetry::{
-    init_metrics, init_tracing_with_otel, shutdown_tracing, start_observability_server,
+    init_metrics, init_tracing_with_otel, shutdown_tracing, start_observability_server, Readiness,
 };
 use huginn_proxy_lib::WatchOptions;
 use tokio::time::Duration;
@@ -70,10 +70,14 @@ async fn main() -> Result<(), BoxError> {
     let (metrics, registry) =
         init_metrics().map_err(|e| format!("Failed to initialize metrics: {e}"))?;
 
+    // Readiness shared between the proxy and the observability server's `/ready` endpoint.
+    // Not-ready until the proxy listeners are accepting; not-ready again on shutdown.
+    let readiness = Readiness::new();
+
     let metrics_service: Option<ServiceHandle> =
         if let Some(metrics_port) = static_cfg.telemetry.metrics_port {
             info!(port = metrics_port, "Metrics initialized, starting observability server");
-            let backends_for_observability = dynamic_cfg.load().backends.clone();
+            let readiness_for_observability = readiness.clone();
             let mut metrics_shutdown = shutdown_rx.clone();
             let handle = tokio::spawn(async move {
                 tokio::select! {
@@ -84,7 +88,7 @@ async fn main() -> Result<(), BoxError> {
                     result = start_observability_server(
                         metrics_port,
                         registry,
-                        backends_for_observability,
+                        readiness_for_observability,
                     ) => {
                         if let Err(e) = result {
                             tracing::error!(error = %e, "Observability server error");
@@ -181,6 +185,7 @@ async fn main() -> Result<(), BoxError> {
         syn_probe,
         watch_opts,
         shutdown_tx,
+        readiness,
     )
     .await;
 


### PR DESCRIPTION
I have decoupled /ready from backend availability: the proxy now gates readiness on listeners accepting connections (via a shared Readiness flag), the eBPF agent still gates on BPF pins, and /health//live remain simple liveness aliases, matching Traefik/Envoy semantics.

I refactored observability HTTP handling into router + shared helpers (RespBody, json_response, typed Status/StatusBody, AgentError in the agent): all observability responses are JSON, proxy error bodies with content use {"error":"..."}, and empty-body errors stay empty.

I added logging so failures are visible: warn! with the reason when /ready fails (proxy_starting, pins_not_ready) or metrics encoding fails, plus a debug! trace per observability request (path + status).

This refactor was required after add multi DNS support