### PR TITLE
eBPF - Memory size agnostic from IP version

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,3 +47,31 @@ The capture hook is selectable via `HUGINN_EBPF_CAPTURE` (`xdp-native` | `xdp-sk
 ### Process lifecycle and failure isolation
 
 The agent and the proxy are decoupled processes. At startup the proxy retries opening the agent's pinned maps with a fixed backoff, so the two can start in any order. Once connected, the proxy holds its own map file descriptors: an agent crash never crashes the proxy, and lookups degrade to `SynResult::Miss` (the `x-tcp-p0f` header is skipped) rather than blocking or dropping traffic. Because the agent reuses its pinned maps across restarts, a normal restart keeps the same kernel IDs and the proxy needs no reconnection at all. As a backstop, a shutdown-aware background task compares the kernel IDs of the published IPv4/IPv6 pins with the active IDs; when the maps are actually recreated (a capacity change, or a wiped bpffs) the proxy opens a complete new map set and publishes it through `ArcSwap`, so in-flight lookups finish on the previous set and new lookups use the replacement without dropping connections. See `EBPF-SETUP.md` for the polling interval and full lifecycle guidance.
+
+The stale-entry threshold needs the LRU capacity. The agent publishes it once into a family-agnostic `syn_meta` map (a sibling of `syn_counter`); the proxy reads it back rather than being configured with it, so it never drifts and does not depend on which IP family is enabled. The value is pinned, so it survives agent restarts/crashes; a freshly recreated map reads `0` until the agent writes it, which the proxy treats as *not ready* and retries.
+
+### Lifecycle scenarios
+
+Maps live in bpffs independently of both processes. The proxy connects via a startup retry loop and stays current via the backstop watcher, both funnelling through a single `ArcSwap<EbpfProbe>`:
+
+```
+startup:   from_pinned() ──Err (pins absent │ MapNotReady)──▶ wait 2s ──┐
+               │ Ok                                            ▲         │
+               ▼                                               └─────────┘
+         ArcSwap<EbpfProbe> ◀── proxy holds its own map FDs (outlive the agent)
+               ▲
+watcher   every HUGINN_EBPF_RECONNECT_POLL_SECS:
+(backstop)   published IDs == active IDs ? ── yes ─▶ keep current maps
+                                           └─ no ──▶ from_pinned() ─▶ ArcSwap.store()
+```
+
+Only the TCP SYN fingerprint (`x-tcp-p0f`) depends on eBPF. TLS JA4 and HTTP/2 Akamai are extracted in-process from the ClientHello and HTTP/2 frames, so they are unaffected by any agent/eBPF state below.
+
+| Event | Maps in bpffs | Proxy reaction | `x-tcp-p0f` header |
+|---|---|---|---|
+| Startup, pins absent | — | retry `from_pinned` every 2s | skipped until connected |
+| `syn_meta` pinned but unwritten | fresh, capacity `0` | `MapNotReady` → retry | skipped (transient) |
+| Agent graceful restart | reused, same IDs | none (IDs unchanged) | uninterrupted |
+| Agent crash (SIGKILL) | survive (pinned) + proxy FDs | none; captures continue (program stays attached) | uninterrupted |
+| Capacity change / bpffs wipe | recreated, new IDs | watcher reopens, atomic `ArcSwap` swap | in-flight on old set, new lookups on new set |
+| Reconnect poll disabled (`=0`) | recreated, new IDs | none until proxy restart | skipped until restart |

--- a/EBPF-SETUP.md
+++ b/EBPF-SETUP.md
@@ -32,6 +32,7 @@ TCP fingerprinting uses two separate processes:
                               │
                     tcp_syn_map_v4/v6  (LruHashMap)
                     syn_counter        (Array)
+                    syn_meta           (Array)
                     syn_insert_failures_v4/v6  (PerCpuArray)
                     syn_captured_v4/v6         (PerCpuArray)
                     syn_malformed_v4/v6        (PerCpuArray)
@@ -105,7 +106,7 @@ No `seccomp:unconfined` or `apparmor:unconfined` needed.
 | `HUGINN_EBPF_DST_IP_V6` | `::` | IPv6 destination filter (`::` = no filter); quote in YAML if needed |
 | `HUGINN_EBPF_DST_PORT` | `7000` | Destination port filter (proxy listen port) |
 | `HUGINN_EBPF_PIN_PATH` | `/sys/fs/bpf/huginn` | Pin directory (default shown) |
-| `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES` | `8192` | LRU map capacity (default shown) |
+| `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES` | `8192` | LRU map capacity (default shown). Agent-only: the agent publishes this value into the family-agnostic `syn_meta` map, and the proxy reads it from there for its staleness threshold — so it must not be set on the proxy. |
 | `HUGINN_EBPF_CAPTURE` | `xdp-native` | Capture backend: `xdp-native` (driver XDP, default), `xdp-skb` (generic XDP, veth/loopback/VMs), or `tc` (clsact ingress; GRO-safe when native XDP is unavailable, e.g. VLAN/bond on generic XDP). Same BPF maps either way. |
 | `HUGINN_EBPF_LOG_LEVEL` | `off` | Verbosity of in-kernel `aya-log` datapath logging: `off` (default), `error`, `warn`, `info`, `debug`, `trace`. The kernel emits only records at/above the level (`debug` = per-capture, `warn` = map-insert failures), so the level gate runs in-kernel and `off` is zero-cost on the hot path. When non-`off` and `RUST_LOG` is unset, the agent defaults its filter to that level so records are shown. For diagnostics only. |
 
@@ -281,7 +282,9 @@ present on all requests** of a keep-alive connection, not just the first.
 
 A `SynResult::Miss` (no header injected) happens when:
 - the SYN was not captured (proxy just started, map entry evicted), or
-- the entry is stale (more than `2 x syn_map_max_entries` SYNs arrived since capture).
+- the entry is stale (more than `2 x syn_map_max_entries` SYNs arrived since capture). The proxy
+  reads `syn_map_max_entries` from the family-agnostic `syn_meta` map the agent publishes, so the
+  threshold always matches the agent's capacity and does not depend on which IP family is enabled.
 
 `force_new_connection = true` is unrelated to fingerprint availability: it controls whether
 the proxy opens a new TCP connection to the **backend** per request, not whether the client

--- a/EBPF-SETUP.md
+++ b/EBPF-SETUP.md
@@ -137,7 +137,6 @@ tcp_enabled = true   # false = no BPF maps opened, no capabilities needed
 | Variable | Example | Description |
 |---|---|---|
 | `HUGINN_EBPF_PIN_PATH` | `/sys/fs/bpf/huginn` | Pin directory to read maps from (default shown) |
-| `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES` | `8192` | LRU map capacity used by the agent; the proxy uses the same value for stale-entry detection |
 | `HUGINN_EBPF_RECONNECT_POLL_SECS` | `5` | Backstop poll interval for detecting recreated maps (e.g. a capacity change or a wiped bpffs); `0` disables automatic reconnection. Normal agent restarts reuse the same maps and need no reconnection |
 
 At startup the proxy retries opening the pinned maps with a fixed backoff until the agent has

--- a/examples/docker-compose.ebpf.yml
+++ b/examples/docker-compose.ebpf.yml
@@ -42,7 +42,6 @@ services:
       - HUGINN_CONFIG_PATH=/config/compose.yaml
       - RUST_LOG=${RUST_LOG:-info}
       - HUGINN_EBPF_PIN_PATH=/sys/fs/bpf/huginn
-      - HUGINN_EBPF_SYN_MAP_MAX_ENTRIES=8192
       - HUGINN_EBPF_RECONNECT_POLL_SECS=5
       - HUGINN_WATCH=true
       - HUGINN_WATCH_DELAY_SECS=10

--- a/examples/docker-compose.release-ebpf.yml
+++ b/examples/docker-compose.release-ebpf.yml
@@ -40,7 +40,6 @@ services:
       - HUGINN_CONFIG_PATH=/config/compose.yaml
       - RUST_LOG=${RUST_LOG:-info}
       - HUGINN_EBPF_PIN_PATH=/sys/fs/bpf/huginn
-      - HUGINN_EBPF_SYN_MAP_MAX_ENTRIES=8192
       - HUGINN_EBPF_RECONNECT_POLL_SECS=5
       - HUGINN_WATCH=true
       - HUGINN_WATCH_DELAY_SECS=10

--- a/huginn-ebpf-programs/src/signals/tcp_syn/maps.rs
+++ b/huginn-ebpf-programs/src/signals/tcp_syn/maps.rs
@@ -16,6 +16,17 @@ pub static tcp_syn_map_v4: LruHashMap<u64, SynRawDataV4> =
 #[allow(non_upper_case_globals)]
 pub static syn_counter: Array<u64> = Array::with_max_entries(1, 0);
 
+// Family-agnostic metadata: slot 0 holds the shared LRU capacity (max_entries) the agent
+// created the SYN maps with. Written by the userspace agent (not the datapath) so the proxy
+// can read the staleness threshold without opening any per-family (v4/v6) map.
+//
+// `#[used]` is required because no BPF program references this map: without it the BPF linker
+// dead-strips the global (export_name alone does not keep it), and aya would never create it.
+#[used]
+#[map]
+#[allow(non_upper_case_globals)]
+pub static syn_meta: Array<u64> = Array::with_max_entries(1, 0);
+
 #[map]
 #[allow(non_upper_case_globals)]
 pub static syn_insert_failures_v4: PerCpuArray<u64> = PerCpuArray::with_max_entries(1, 0);

--- a/huginn-ebpf/src/error.rs
+++ b/huginn-ebpf/src/error.rs
@@ -36,6 +36,9 @@ pub enum EbpfError {
         source: aya::maps::MapError,
     },
 
+    #[error("BPF map '{name}' not found in loaded object")]
+    MapNotFound { name: String },
+
     #[error("failed to create pin directory '{path}': {source}")]
     PinDir {
         path: String,

--- a/huginn-ebpf/src/error.rs
+++ b/huginn-ebpf/src/error.rs
@@ -39,6 +39,9 @@ pub enum EbpfError {
     #[error("BPF map '{name}' not found in loaded object")]
     MapNotFound { name: String },
 
+    #[error("BPF map '{name}' is not populated yet (agent has not published its value)")]
+    MapNotReady { name: String },
+
     #[error("failed to create pin directory '{path}': {source}")]
     PinDir {
         path: String,

--- a/huginn-ebpf/src/pin.rs
+++ b/huginn-ebpf/src/pin.rs
@@ -4,6 +4,7 @@ pub const DEFAULT_PIN_BASE: &str = "/sys/fs/bpf/huginn";
 
 pub const SYN_MAP_V4_NAME: &str = "tcp_syn_map_v4";
 pub const COUNTER_NAME: &str = "syn_counter";
+pub const SYN_META_NAME: &str = "syn_meta";
 pub const SYN_INSERT_FAILURES_V4_NAME: &str = "syn_insert_failures_v4";
 pub const SYN_CAPTURED_V4_NAME: &str = "syn_captured_v4";
 pub const SYN_MALFORMED_V4_NAME: &str = "syn_malformed_v4";
@@ -14,10 +15,11 @@ pub const SYN_CAPTURED_V6_NAME: &str = "syn_captured_v6";
 pub const SYN_MALFORMED_V6_NAME: &str = "syn_malformed_v6";
 
 /// Every map the agent pins and the proxy opens, in no particular order.
-pub const ALL_NAMES: [&str; 9] = [
+pub const ALL_NAMES: [&str; 10] = [
     SYN_MAP_V4_NAME,
     SYN_MAP_V6_NAME,
     COUNTER_NAME,
+    SYN_META_NAME,
     SYN_INSERT_FAILURES_V4_NAME,
     SYN_CAPTURED_V4_NAME,
     SYN_MALFORMED_V4_NAME,
@@ -32,6 +34,10 @@ pub fn syn_map_v4_path(base: &str) -> PathBuf {
 
 pub fn counter_path(base: &str) -> PathBuf {
     Path::new(base).join(COUNTER_NAME)
+}
+
+pub fn syn_meta_path(base: &str) -> PathBuf {
+    Path::new(base).join(SYN_META_NAME)
 }
 
 pub fn insert_failures_v4_path(base: &str) -> PathBuf {

--- a/huginn-ebpf/src/probe/maps.rs
+++ b/huginn-ebpf/src/probe/maps.rs
@@ -2,7 +2,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
 use aya::maps::{MapData, MapInfo};
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::pin;
 use crate::EbpfError;
@@ -17,7 +17,7 @@ impl EbpfProbe {
     /// [`EbpfProbe::new`]). Exposed for manual cleanup / tests.
     pub fn unpin_maps(base_path: &str) {
         remove_all_pins(base_path);
-        info!(base_path, "BPF map pins removed");
+        warn!(base_path, "BPF map pins removed");
     }
 }
 
@@ -94,5 +94,12 @@ pub(super) fn pinned_map_id(path: PathBuf) -> Result<u32, EbpfError> {
 pub(super) fn open_map_id(map: &MapData, path: PathBuf) -> Result<u32, EbpfError> {
     map.info()
         .map(|info| info.id())
+        .map_err(|e| EbpfError::MapInfo { path: path.display().to_string(), source: e })
+}
+
+/// Return the capacity (`max_entries`) of an already-open BPF map.
+pub(super) fn open_map_max_entries(map: &MapData, path: PathBuf) -> Result<u32, EbpfError> {
+    map.info()
+        .map(|info| info.max_entries())
         .map_err(|e| EbpfError::MapInfo { path: path.display().to_string(), source: e })
 }

--- a/huginn-ebpf/src/probe/maps.rs
+++ b/huginn-ebpf/src/probe/maps.rs
@@ -1,7 +1,8 @@
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
-use aya::maps::{MapData, MapInfo};
+use aya::maps::{Array, Map, MapData, MapInfo};
+use aya::Ebpf;
 use tracing::{info, warn};
 
 use crate::pin;
@@ -97,9 +98,36 @@ pub(super) fn open_map_id(map: &MapData, path: PathBuf) -> Result<u32, EbpfError
         .map_err(|e| EbpfError::MapInfo { path: path.display().to_string(), source: e })
 }
 
-/// Return the capacity (`max_entries`) of an already-open BPF map.
-pub(super) fn open_map_max_entries(map: &MapData, path: PathBuf) -> Result<u32, EbpfError> {
-    map.info()
-        .map(|info| info.max_entries())
-        .map_err(|e| EbpfError::MapInfo { path: path.display().to_string(), source: e })
+/// Publish the shared LRU capacity into slot 0 of the family-agnostic `syn_meta` map.
+///
+/// Called by the agent right after loading so the proxy can read the staleness threshold
+/// without opening any per-family (v4/v6) SYN map. The value is the same one used to create
+/// the LRU maps, so it cannot drift from their actual `max_entries`.
+pub(super) fn write_syn_capacity(
+    ebpf: &mut Ebpf,
+    syn_map_max_entries: u32,
+) -> Result<(), EbpfError> {
+    let map = ebpf
+        .map_mut(pin::SYN_META_NAME)
+        .ok_or_else(|| EbpfError::MapNotFound { name: pin::SYN_META_NAME.to_string() })?;
+    let mut meta = Array::<_, u64>::try_from(map)
+        .map_err(|source| EbpfError::FromPin { path: pin::SYN_META_NAME.to_string(), source })?;
+    meta.set(0, u64::from(syn_map_max_entries), 0)
+        .map_err(|source| EbpfError::MapInfo { path: pin::SYN_META_NAME.to_string(), source })
+}
+
+/// Read the shared LRU capacity the agent published to slot 0 of the pinned `syn_meta` map.
+///
+/// Returns `0` when the slot has not been written yet (a fresh map before the agent's first
+/// write); the caller treats that as "not populated" and falls back to a default.
+pub(super) fn read_syn_capacity(base_path: &str) -> Result<u32, EbpfError> {
+    let path = pin::syn_meta_path(base_path);
+    let data = open_pinned_map(path.clone())?;
+    let map = Map::Array(data);
+    let array = Array::<_, u64>::try_from(&map)
+        .map_err(|source| EbpfError::FromPin { path: path.display().to_string(), source })?;
+    let value = array
+        .get(&0, 0)
+        .map_err(|source| EbpfError::MapInfo { path: path.display().to_string(), source })?;
+    Ok(u32::try_from(value).unwrap_or(u32::MAX))
 }

--- a/huginn-ebpf/src/probe/mod.rs
+++ b/huginn-ebpf/src/probe/mod.rs
@@ -173,6 +173,10 @@ impl EbpfProbe {
         }
         let mut ebpf = loader.load(BPF_OBJECT_BYTES).map_err(EbpfError::Load)?;
 
+        // Publish the LRU capacity to the family-agnostic `syn_meta` map so the proxy can
+        // derive its staleness threshold without opening a per-family SYN map.
+        maps::write_syn_capacity(&mut ebpf, syn_map_max_entries)?;
+
         // aya creates pins as 0600 root:root; relax them for the proxy process.
         maps::chmod_pins(pin_base);
 
@@ -213,22 +217,24 @@ impl EbpfProbe {
     /// The agent must have already pinned `tcp_syn_map_v4`, `tcp_syn_map_v6`, `syn_counter`,
     /// and `syn_insert_failures` under `base_path` (default: `/sys/fs/bpf/huginn/`).
     ///
-    /// The LRU capacity used for stale-entry detection is read from the pinned SYN map itself
-    /// (`max_entries`), so it always matches the value the agent created the map with, with no
-    /// separate configuration that could drift. This constructor does not load or attach any XDP
-    /// program, the agent owns that lifecycle.
+    /// The LRU capacity used for stale-entry detection is read from the family-agnostic
+    /// `syn_meta` map (populated by the agent with the same value it created the SYN maps with),
+    /// so it never drifts and does not depend on which IP family is enabled. This constructor
+    /// does not load or attach any XDP program, the agent owns that lifecycle.
     pub fn from_pinned(base_path: &str) -> Result<Self, EbpfError> {
         let syn_path_v4 = pin::syn_map_v4_path(base_path);
         let syn_path_v6 = pin::syn_map_v6_path(base_path);
         let syn_data_v4 = maps::open_pinned_map(syn_path_v4.clone())?;
         let syn_data_v6 = maps::open_pinned_map(syn_path_v6.clone())?;
-        let syn_id_v4 = maps::open_map_id(&syn_data_v4, syn_path_v4.clone())?;
+        let syn_id_v4 = maps::open_map_id(&syn_data_v4, syn_path_v4)?;
         let syn_id_v6 = maps::open_map_id(&syn_data_v6, syn_path_v6)?;
-        // Shared LRU capacity: a single value that pairs with the global `syn_counter`
-        // for staleness (both families are created equal by the agent, so it is read
-        // from either SYN map). Sourced from the kernel rather than a proxy-side env
-        // var that could drift from the agent's value. TODO: ....
-        let syn_map_max_entries = maps::open_map_max_entries(&syn_data_v4, syn_path_v4)?;
+        // Shared LRU capacity for staleness detection, read from the global `syn_meta` map
+        // (decoupled from v4/v6). A zero means the agent has not written it yet (fresh map);
+        // fall back to the default until the value is published.
+        let syn_map_max_entries = match maps::read_syn_capacity(base_path)? {
+            0 => DEFAULT_SYN_MAP_MAX_ENTRIES,
+            capacity => capacity,
+        };
         let counter_data = maps::open_pinned_map(pin::counter_path(base_path))?;
         let insert_failures_v4 = maps::open_pinned_map(pin::insert_failures_v4_path(base_path))?;
         let insert_failures_v6 = maps::open_pinned_map(pin::insert_failures_v6_path(base_path))?;

--- a/huginn-ebpf/src/probe/mod.rs
+++ b/huginn-ebpf/src/probe/mod.rs
@@ -213,16 +213,22 @@ impl EbpfProbe {
     /// The agent must have already pinned `tcp_syn_map_v4`, `tcp_syn_map_v6`, `syn_counter`,
     /// and `syn_insert_failures` under `base_path` (default: `/sys/fs/bpf/huginn/`).
     ///
-    /// `syn_map_max_entries` must match the value the agent used when loading the program
-    /// (e.g. `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES`); it is used for stale entry detection.
-    /// This constructor does not load or attach any XDP program, the agent owns that lifecycle.
-    pub fn from_pinned(base_path: &str, syn_map_max_entries: u32) -> Result<Self, EbpfError> {
+    /// The LRU capacity used for stale-entry detection is read from the pinned SYN map itself
+    /// (`max_entries`), so it always matches the value the agent created the map with, with no
+    /// separate configuration that could drift. This constructor does not load or attach any XDP
+    /// program, the agent owns that lifecycle.
+    pub fn from_pinned(base_path: &str) -> Result<Self, EbpfError> {
         let syn_path_v4 = pin::syn_map_v4_path(base_path);
         let syn_path_v6 = pin::syn_map_v6_path(base_path);
-        let syn_data = maps::open_pinned_map(syn_path_v4.clone())?;
+        let syn_data_v4 = maps::open_pinned_map(syn_path_v4.clone())?;
         let syn_data_v6 = maps::open_pinned_map(syn_path_v6.clone())?;
-        let syn_id_v4 = maps::open_map_id(&syn_data, syn_path_v4)?;
+        let syn_id_v4 = maps::open_map_id(&syn_data_v4, syn_path_v4.clone())?;
         let syn_id_v6 = maps::open_map_id(&syn_data_v6, syn_path_v6)?;
+        // Shared LRU capacity: a single value that pairs with the global `syn_counter`
+        // for staleness (both families are created equal by the agent, so it is read
+        // from either SYN map). Sourced from the kernel rather than a proxy-side env
+        // var that could drift from the agent's value. TODO: ....
+        let syn_map_max_entries = maps::open_map_max_entries(&syn_data_v4, syn_path_v4)?;
         let counter_data = maps::open_pinned_map(pin::counter_path(base_path))?;
         let insert_failures_v4 = maps::open_pinned_map(pin::insert_failures_v4_path(base_path))?;
         let insert_failures_v6 = maps::open_pinned_map(pin::insert_failures_v6_path(base_path))?;
@@ -236,7 +242,7 @@ impl EbpfProbe {
         Ok(Self {
             inner: ProbeInner::Pinned(Box::new(PinnedMaps {
                 ipv4: PinnedFamilyMaps {
-                    syn: Map::LruHashMap(syn_data),
+                    syn: Map::LruHashMap(syn_data_v4),
                     id: syn_id_v4,
                     insert_failures: Map::PerCpuArray(insert_failures_v4),
                     captured: Map::PerCpuArray(captured_v4),

--- a/huginn-ebpf/src/probe/mod.rs
+++ b/huginn-ebpf/src/probe/mod.rs
@@ -221,6 +221,9 @@ impl EbpfProbe {
     /// `syn_meta` map (populated by the agent with the same value it created the SYN maps with),
     /// so it never drifts and does not depend on which IP family is enabled. This constructor
     /// does not load or attach any XDP program, the agent owns that lifecycle.
+    ///
+    /// Returns [`EbpfError::MapNotReady`] if the agent has pinned the maps but not yet published
+    /// the capacity; callers are expected to retry.
     pub fn from_pinned(base_path: &str) -> Result<Self, EbpfError> {
         let syn_path_v4 = pin::syn_map_v4_path(base_path);
         let syn_path_v6 = pin::syn_map_v6_path(base_path);
@@ -228,11 +231,9 @@ impl EbpfProbe {
         let syn_data_v6 = maps::open_pinned_map(syn_path_v6.clone())?;
         let syn_id_v4 = maps::open_map_id(&syn_data_v4, syn_path_v4)?;
         let syn_id_v6 = maps::open_map_id(&syn_data_v6, syn_path_v6)?;
-        // Shared LRU capacity for staleness detection, read from the global `syn_meta` map
-        // (decoupled from v4/v6). A zero means the agent has not written it yet (fresh map);
-        // fall back to the default until the value is published.
+        // Zero = agent pinned the map but has not written the capacity yet; not ready.
         let syn_map_max_entries = match maps::read_syn_capacity(base_path)? {
-            0 => DEFAULT_SYN_MAP_MAX_ENTRIES,
+            0 => return Err(EbpfError::MapNotReady { name: pin::SYN_META_NAME.to_string() }),
             capacity => capacity,
         };
         let counter_data = maps::open_pinned_map(pin::counter_path(base_path))?;

--- a/huginn-proxy/src/ebpf/config.rs
+++ b/huginn-proxy/src/ebpf/config.rs
@@ -11,53 +11,15 @@ pub enum ParseError {
     },
 }
 
-fn parse_optional_u64(
-    name: &'static str,
-    raw: Option<String>,
-    default: u64,
-    reason: &'static str,
-) -> Result<u64, ParseError> {
-    raw.map(|value| {
-        value
-            .parse()
-            .map_err(|_| ParseError::Invalid { name, value, reason })
-    })
-    .transpose()
-    .map(|opt| opt.unwrap_or(default))
-}
-
-fn parse_optional_u32(
-    name: &'static str,
-    raw: Option<String>,
-    default: u32,
-    reason: &'static str,
-) -> Result<u32, ParseError> {
-    raw.map(|value| {
-        value
-            .parse()
-            .map_err(|_| ParseError::Invalid { name, value, reason })
-    })
-    .transpose()
-    .map(|opt| opt.unwrap_or(default))
-}
-
-/// Parse `HUGINN_EBPF_RECONNECT_POLL_SECS`, defaulting when unset (same pattern as
-/// `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES` in the eBPF agent).
+/// Parse `HUGINN_EBPF_RECONNECT_POLL_SECS`, defaulting when unset.
 pub fn reconnect_poll_secs_from_env(raw: Option<String>) -> Result<u64, ParseError> {
-    parse_optional_u64(
-        "HUGINN_EBPF_RECONNECT_POLL_SECS",
-        raw,
-        DEFAULT_RECONNECT_POLL_SECS,
-        "must be a non-negative integer",
-    )
-}
-
-/// Parse `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES`, defaulting when unset.
-pub fn syn_map_max_entries_from_env(raw: Option<String>, default: u32) -> Result<u32, ParseError> {
-    parse_optional_u32(
-        "HUGINN_EBPF_SYN_MAP_MAX_ENTRIES",
-        raw,
-        default,
-        "must be a positive integer",
-    )
+    raw.map(|value| {
+        value.parse().map_err(|_| ParseError::Invalid {
+            name: "HUGINN_EBPF_RECONNECT_POLL_SECS",
+            value,
+            reason: "must be a non-negative integer",
+        })
+    })
+    .transpose()
+    .map(|opt| opt.unwrap_or(DEFAULT_RECONNECT_POLL_SECS))
 }

--- a/huginn-proxy/src/ebpf/mod.rs
+++ b/huginn-proxy/src/ebpf/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 #[cfg(feature = "ebpf-tcp")]
 use {
-    self::config::{reconnect_poll_secs_from_env, syn_map_max_entries_from_env},
+    self::config::reconnect_poll_secs_from_env,
     arc_swap::ArcSwap,
     huginn_ebpf::{parse_syn_v4, parse_syn_v6, EbpfProbe},
     huginn_proxy_lib::fingerprinting::SynResult,
@@ -33,16 +33,6 @@ pub async fn connect_syn_probe(
 
     let pin_path = env::var("HUGINN_EBPF_PIN_PATH")
         .unwrap_or_else(|_| huginn_ebpf::pin::DEFAULT_PIN_BASE.to_string());
-    let syn_map_max_entries = match syn_map_max_entries_from_env(
-        env::var("HUGINN_EBPF_SYN_MAP_MAX_ENTRIES").ok(),
-        huginn_ebpf::DEFAULT_SYN_MAP_MAX_ENTRIES,
-    ) {
-        Ok(value) => value,
-        Err(error) => {
-            tracing::error!(%error, "invalid eBPF configuration");
-            return (None, None);
-        }
-    };
     let reconnect_poll_secs =
         match reconnect_poll_secs_from_env(env::var("HUGINN_EBPF_RECONNECT_POLL_SECS").ok()) {
             Ok(value) => value,
@@ -53,7 +43,7 @@ pub async fn connect_syn_probe(
         };
 
     let probe = loop {
-        match EbpfProbe::from_pinned(&pin_path, syn_map_max_entries) {
+        match EbpfProbe::from_pinned(&pin_path) {
             Ok(probe) => break probe,
             Err(_) => {
                 tracing::warn!(
@@ -79,14 +69,8 @@ pub async fn connect_syn_probe(
     }
 
     let poll_interval = Duration::from_secs(reconnect_poll_secs);
-    let handle = tokio::spawn(watch_pinned_maps(
-        probe,
-        pin_path,
-        syn_map_max_entries,
-        poll_interval,
-        metrics,
-        shutdown_rx,
-    ));
+    let handle =
+        tokio::spawn(watch_pinned_maps(probe, pin_path, poll_interval, metrics, shutdown_rx));
     let watcher = ServiceHandle { handle, name: ServiceName::EbpfReconnect };
     (Some(syn_probe), Some(watcher))
 }
@@ -119,7 +103,6 @@ fn lookup_syn(probe: &EbpfProbe, peer: SocketAddr) -> SynResult {
 async fn watch_pinned_maps(
     probe: Arc<ArcSwap<EbpfProbe>>,
     pin_path: String,
-    syn_map_max_entries: u32,
     poll_interval: Duration,
     metrics: Arc<Metrics>,
     mut shutdown_rx: ShutdownWatch,
@@ -139,7 +122,6 @@ async fn watch_pinned_maps(
                 if let Err(error) = reconnect_if_changed(
                     &probe,
                     &pin_path,
-                    syn_map_max_entries,
                     &metrics,
                 ) {
                     tracing::debug!(
@@ -157,7 +139,6 @@ async fn watch_pinned_maps(
 fn reconnect_if_changed(
     probe: &ArcSwap<EbpfProbe>,
     pin_path: &str,
-    syn_map_max_entries: u32,
     metrics: &Metrics,
 ) -> Result<(), huginn_ebpf::EbpfError> {
     let current = probe.load();
@@ -170,7 +151,7 @@ fn reconnect_if_changed(
     }
     drop(current);
 
-    let replacement = EbpfProbe::from_pinned(pin_path, syn_map_max_entries)?;
+    let replacement = EbpfProbe::from_pinned(pin_path)?;
     let Some(new_ids) = replacement.pinned_map_ids() else {
         return Ok(());
     };

--- a/huginn-proxy/tests/ebpf/config.rs
+++ b/huginn-proxy/tests/ebpf/config.rs
@@ -1,7 +1,5 @@
-use huginn_ebpf::DEFAULT_SYN_MAP_MAX_ENTRIES;
 use huginn_proxy::ebpf::config::{
-    reconnect_poll_secs_from_env, syn_map_max_entries_from_env, ParseError,
-    DEFAULT_RECONNECT_POLL_SECS,
+    reconnect_poll_secs_from_env, ParseError, DEFAULT_RECONNECT_POLL_SECS,
 };
 
 #[test]
@@ -25,24 +23,4 @@ fn reconnect_poll_rejects_invalid_values() {
 fn reconnect_poll_accepts_zero_and_positive_values() {
     assert_eq!(reconnect_poll_secs_from_env(Some("0".to_string())), Ok(0));
     assert_eq!(reconnect_poll_secs_from_env(Some("17".to_string())), Ok(17));
-}
-
-#[test]
-fn syn_map_max_entries_uses_default_when_unset() {
-    assert_eq!(
-        syn_map_max_entries_from_env(None, DEFAULT_SYN_MAP_MAX_ENTRIES),
-        Ok(DEFAULT_SYN_MAP_MAX_ENTRIES)
-    );
-}
-
-#[test]
-fn syn_map_max_entries_rejects_invalid_values() {
-    assert_eq!(
-        syn_map_max_entries_from_env(Some("nope".to_string()), DEFAULT_SYN_MAP_MAX_ENTRIES),
-        Err(ParseError::Invalid {
-            name: "HUGINN_EBPF_SYN_MAP_MAX_ENTRIES",
-            value: "nope".to_string(),
-            reason: "must be a positive integer",
-        })
-    );
 }


### PR DESCRIPTION
## Decouple SYN map capacity from IP family (v4/v6)

The proxy previously read the LRU capacity (used for the stale-entry threshold) from the IPv4 SYN map, coupling it to the assumption that v4 always exists, fragile now that IP families are configurable. This adds a global, family-agnostic `syn_meta` map (sibling of `syn_counter`) that the agent populates once with the capacity and the proxy reads without touching any family map; `#[used]` is required so the BPF linker keeps the map even though no kernel program references it. The value is pinned to bpffs, so it survives agent restarts/crashes and never drifts (same variable that creates the LRU maps). If the map is pinned but not yet populated, `from_pinned` returns `MapNotReady` and the existing retry loop waits rather than guessing a default.