### PR TITLE
Add rate-limit config validation + canonical peer normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ follows [Semantic Versioning](https://semver.org/).
 - **Config validation warnings + `--validate --strict`.** Config loading audits for likely mistakes
   and logs non-fatal warnings (boot, `--validate`, hot reload): duplicate/contradictory header
   manipulation, security overrides that drop parent protection, over-broad `trusted_proxies` ranges,
-  an enabled `rate_limit` with `window_seconds = 0`, and `proxy_protocol` with no trusted peer.
-  `--validate` prints a warning count; `--strict` exits non-zero on any warning. See `SETTINGS.md`.
+  a self-defeating `rate_limit` (`window_seconds = 0`, or `limit_by = "header"` with no
+  `limit_by_header`), and `proxy_protocol` with no trusted peer. `--validate` prints a warning count;
+  `--strict` exits non-zero on any warning. See `SETTINGS.md`.
 
 ### Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ follows [Semantic Versioning](https://semver.org/).
 - **Config validation warnings + `--validate --strict`.** Config loading audits for likely mistakes
   and logs non-fatal warnings (boot, `--validate`, hot reload): duplicate/contradictory header
   manipulation, security overrides that drop parent protection, over-broad `trusted_proxies` ranges,
-  and `proxy_protocol` with no trusted peer. `--validate` prints a warning count; `--strict` exits
-  non-zero on any warning. See `SETTINGS.md`.
+  an enabled `rate_limit` with `window_seconds = 0`, and `proxy_protocol` with no trusted peer.
+  `--validate` prints a warning count; `--strict` exits non-zero on any warning. See `SETTINGS.md`.
 
 ### Breaking changes
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -388,8 +388,9 @@ Reload triggers and config:
 On reload, if the new config is invalid the proxy keeps the current config and logs the error. If static sections
 changed, the proxy logs an error and ignores those changes (restart required).
 
-On load, `--validate`, and every reload the proxy also emits a **non-fatal `WARN`** when a whole-block override (domain
-or route) drops a protection the parent had enabled — e.g. a partial `rate_limit`/`ip_filter`/`headers` block that
-silently disables a globally-enabled policy. It never aborts, since dropping a policy may be intended.
+On load, `--validate`, and every reload the proxy also emits **non-fatal `WARN`s** for likely config mistakes — e.g. a
+whole-block override (domain or route) that drops a protection the parent had enabled (a partial
+`rate_limit`/`ip_filter`/`headers` block silently disabling a globally-enabled policy), or an enabled `rate_limit` with
+`window_seconds = 0` (cannot compute a rate). These never abort, since some of them may be intended.
 
 Limitation: No per-section partial reload. Dynamic config is always swapped as a whole.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -390,7 +390,8 @@ changed, the proxy logs an error and ignores those changes (restart required).
 
 On load, `--validate`, and every reload the proxy also emits **non-fatal `WARN`s** for likely config mistakes — e.g. a
 whole-block override (domain or route) that drops a protection the parent had enabled (a partial
-`rate_limit`/`ip_filter`/`headers` block silently disabling a globally-enabled policy), or an enabled `rate_limit` with
-`window_seconds = 0` (cannot compute a rate). These never abort, since some of them may be intended.
+`rate_limit`/`ip_filter`/`headers` block silently disabling a globally-enabled policy), or an enabled `rate_limit` that is
+self-defeating (`window_seconds = 0`, or `limit_by = "header"` with no `limit_by_header` so it silently keys by IP).
+These never abort, since some of them may be intended.
 
 Limitation: No per-section partial reload. Dynamic config is always swapped as a whole.

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1363,7 +1363,7 @@ The real client IP used for `limit_by = "ip" | "combined"` is resolved from the 
 | `enabled`             | bool    | `false` | Enable global rate limiting.                                                        |
 | `requests_per_second` | integer | `1000`  | Sustained request rate allowed.                                                     |
 | `burst`               | integer | `2000`  | Maximum burst size above the sustained rate.                                        |
-| `window_seconds`      | integer | `1`     | Sliding window in seconds for the token bucket refill.                              |
+| `window_seconds`      | integer | `1`     | Sliding window in seconds for the token bucket refill. Must be `> 0` when `enabled` — an enabled limiter with `window_seconds = 0` emits a non-fatal validation warning. |
 | `limit_by`            | string       | `"ip"`  | Key used to track limits: `"ip"`, `"header"`, `"route"`, `"combined"` (IP + route). |
 | `limit_by_header`     | string       | `null`  | Header name to use as the rate limit key when `limit_by = "header"`.                |
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1365,7 +1365,7 @@ The real client IP used for `limit_by = "ip" | "combined"` is resolved from the 
 | `burst`               | integer | `2000`  | Maximum burst size above the sustained rate.                                        |
 | `window_seconds`      | integer | `1`     | Sliding window in seconds for the token bucket refill. Must be `> 0` when `enabled` — an enabled limiter with `window_seconds = 0` emits a non-fatal validation warning. |
 | `limit_by`            | string       | `"ip"`  | Key used to track limits: `"ip"`, `"header"`, `"route"`, `"combined"` (IP + route). |
-| `limit_by_header`     | string       | `null`  | Header name to use as the rate limit key when `limit_by = "header"`.                |
+| `limit_by_header`     | string       | `null`  | Header name to use as the rate limit key when `limit_by = "header"`. Required in that mode — if missing, the limiter silently falls back to the client IP and a non-fatal validation warning is emitted. |
 
 <table>
 <thead>

--- a/huginn-proxy-lib/src/config/audit/mod.rs
+++ b/huginn-proxy-lib/src/config/audit/mod.rs
@@ -8,7 +8,7 @@
 //! | Submodule            | Pure entry point             | Detects                                   |
 //! |----------------------|------------------------------|-------------------------------------------|
 //! | [`headers`]          | [`header_config_warnings`]   | duplicate / contradictory header config   |
-//! | [`rate_limit`]       | [`rate_limit_warnings`]      | enabled rate limit with zero window       |
+//! | [`rate_limit`]       | [`rate_limit_warnings`]      | enabled rate limit with a broken config   |
 //! | [`security_overrides`] | [`security_override_warnings`] | whole-block overrides dropping protection |
 //! | [`trusted_proxies`]  | [`trusted_proxies_warnings`] | over-broad `trusted_proxies` ranges       |
 

--- a/huginn-proxy-lib/src/config/audit/mod.rs
+++ b/huginn-proxy-lib/src/config/audit/mod.rs
@@ -8,11 +8,13 @@
 //! | Submodule            | Pure entry point             | Detects                                   |
 //! |----------------------|------------------------------|-------------------------------------------|
 //! | [`headers`]          | [`header_config_warnings`]   | duplicate / contradictory header config   |
+//! | [`rate_limit`]       | [`rate_limit_warnings`]      | enabled rate limit with zero window       |
 //! | [`security_overrides`] | [`security_override_warnings`] | whole-block overrides dropping protection |
 //! | [`trusted_proxies`]  | [`trusted_proxies_warnings`] | over-broad `trusted_proxies` ranges       |
 
 mod headers;
 pub(crate) mod proxy_protocol;
+mod rate_limit;
 mod security_overrides;
 mod trusted_proxies;
 
@@ -20,6 +22,7 @@ use tracing::warn;
 
 pub use headers::header_config_warnings;
 pub use proxy_protocol::proxy_protocol_trust_warnings;
+pub use rate_limit::rate_limit_warnings;
 pub use security_overrides::security_override_warnings;
 pub use trusted_proxies::trusted_proxies_warnings;
 
@@ -39,6 +42,7 @@ pub struct ConfigWarning {
 /// own runtime logger and is only surfaced by `--validate`.
 pub fn all_warnings(cfg: &Config) -> Vec<ConfigWarning> {
     let mut out = header_config_warnings(cfg);
+    out.extend(rate_limit_warnings(cfg));
     out.extend(security_override_warnings(cfg));
     out.extend(trusted_proxies_warnings(cfg));
     out

--- a/huginn-proxy-lib/src/config/audit/rate_limit.rs
+++ b/huginn-proxy-lib/src/config/audit/rate_limit.rs
@@ -1,0 +1,46 @@
+//! Audit for rate-limit blocks that can never compute a valid rate.
+
+use super::ConfigWarning;
+use crate::config::{Config, RateLimitConfig};
+
+/// Push a finding when an enabled rate limit has a zero-length window. The limiter is built with
+/// `Duration::from_secs(window_seconds)`, so a `0` window cannot express any rate.
+fn check_window(out: &mut Vec<ConfigWarning>, scope: String, rl: &RateLimitConfig) {
+    if rl.enabled && rl.window_seconds == 0 {
+        out.push(ConfigWarning {
+            scope,
+            message: "rate_limit is enabled but window_seconds is 0; the limiter cannot compute a \
+                      rate (window_seconds must be > 0)"
+                .to_string(),
+        });
+    }
+}
+
+/// Non-fatal audit for rate-limit blocks with a zero `window_seconds`.
+///
+/// A `window_seconds` of 0 is never valid for an enabled limiter, so it is flagged wherever a
+/// rate_limit block is configured (global, per-domain, per-route). Disabled blocks are ignored
+/// since no limiter is built.
+pub fn rate_limit_warnings(cfg: &Config) -> Vec<ConfigWarning> {
+    let mut out = Vec::new();
+
+    check_window(&mut out, "global rate_limit".to_string(), &cfg.security.rate_limit);
+
+    for domain in &cfg.domains {
+        let label = domain.label();
+        if let Some(rl) = domain.security.as_ref().and_then(|s| s.rate_limit.as_ref()) {
+            check_window(&mut out, format!("domain '{label}' rate_limit"), rl);
+        }
+        for route in &domain.routes {
+            if let Some(rl) = route.security.as_ref().and_then(|s| s.rate_limit.as_ref()) {
+                check_window(
+                    &mut out,
+                    format!("route '{}' in domain '{label}' rate_limit", route.prefix),
+                    rl,
+                );
+            }
+        }
+    }
+
+    out
+}

--- a/huginn-proxy-lib/src/config/audit/rate_limit.rs
+++ b/huginn-proxy-lib/src/config/audit/rate_limit.rs
@@ -1,41 +1,59 @@
-//! Audit for rate-limit blocks that can never compute a valid rate.
+//! Audit for enabled rate-limit blocks with a config that silently breaks the limiter.
 
 use super::ConfigWarning;
-use crate::config::{Config, RateLimitConfig};
+use crate::config::{Config, LimitBy, RateLimitConfig};
 
-/// Push a finding when an enabled rate limit has a zero-length window. The limiter is built with
-/// `Duration::from_secs(window_seconds)`, so a `0` window cannot express any rate.
-fn check_window(out: &mut Vec<ConfigWarning>, scope: String, rl: &RateLimitConfig) {
-    if rl.enabled && rl.window_seconds == 0 {
-        out.push(ConfigWarning {
-            scope,
-            message: "rate_limit is enabled but window_seconds is 0; the limiter cannot compute a \
-                      rate (window_seconds must be > 0)"
-                .to_string(),
-        });
+/// Findings for one enabled rate-limit block. Disabled blocks build no limiter, so they are skipped.
+///
+/// Catches two silent footguns:
+/// - `window_seconds == 0`: the limiter is built with `Duration::from_secs(0)` and cannot express a
+///   rate.
+/// - `limit_by = "header"` without a `limit_by_header`: at runtime the key extraction falls back to
+///   the peer IP, silently limiting by IP instead of the intended header.
+fn check_block(out: &mut Vec<ConfigWarning>, scope: &str, rl: &RateLimitConfig) {
+    if !rl.enabled {
+        return;
+    }
+    let mut push = |message: &str| {
+        out.push(ConfigWarning { scope: scope.to_string(), message: message.to_string() });
+    };
+    if rl.window_seconds == 0 {
+        push(
+            "rate_limit is enabled but window_seconds is 0; the limiter cannot compute a rate \
+             (window_seconds must be > 0)",
+        );
+    }
+    let header_missing = rl
+        .limit_by_header
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty();
+    if rl.limit_by == LimitBy::Header && header_missing {
+        push(
+            "rate_limit uses limit_by = \"header\" but limit_by_header is empty; the limiter \
+             silently falls back to limiting by client IP",
+        );
     }
 }
 
-/// Non-fatal audit for rate-limit blocks with a zero `window_seconds`.
-///
-/// A `window_seconds` of 0 is never valid for an enabled limiter, so it is flagged wherever a
-/// rate_limit block is configured (global, per-domain, per-route). Disabled blocks are ignored
-/// since no limiter is built.
+/// Non-fatal audit for enabled rate-limit blocks with a limiter-breaking config, flagged wherever a
+/// block is configured (global, per-domain, per-route). Disabled blocks are ignored.
 pub fn rate_limit_warnings(cfg: &Config) -> Vec<ConfigWarning> {
     let mut out = Vec::new();
 
-    check_window(&mut out, "global rate_limit".to_string(), &cfg.security.rate_limit);
+    check_block(&mut out, "global rate_limit", &cfg.security.rate_limit);
 
     for domain in &cfg.domains {
         let label = domain.label();
         if let Some(rl) = domain.security.as_ref().and_then(|s| s.rate_limit.as_ref()) {
-            check_window(&mut out, format!("domain '{label}' rate_limit"), rl);
+            check_block(&mut out, &format!("domain '{label}' rate_limit"), rl);
         }
         for route in &domain.routes {
             if let Some(rl) = route.security.as_ref().and_then(|s| s.rate_limit.as_ref()) {
-                check_window(
+                check_block(
                     &mut out,
-                    format!("route '{}' in domain '{label}' rate_limit", route.prefix),
+                    &format!("route '{}' in domain '{label}' rate_limit", route.prefix),
                     rl,
                 );
             }

--- a/huginn-proxy-lib/src/config/mod.rs
+++ b/huginn-proxy-lib/src/config/mod.rs
@@ -10,7 +10,7 @@ mod loader;
 mod root;
 
 pub use audit::{
-    all_warnings, header_config_warnings, proxy_protocol_trust_warnings,
+    all_warnings, header_config_warnings, proxy_protocol_trust_warnings, rate_limit_warnings,
     security_override_warnings, trusted_proxies_warnings, ConfigWarning,
 };
 pub use dynamic::security::{

--- a/huginn-proxy-lib/src/proxy/handler/request.rs
+++ b/huginn-proxy-lib/src/proxy/handler/request.rs
@@ -80,7 +80,13 @@ fn enforce_ip_access(
     Ok(())
 }
 
-/// Handle request routing and forwarding
+/// Handle request routing and forwarding.
+///
+/// `peer` is the effective client address as resolved by `resolve_peer`, and is expected to be
+/// already canonicalized: IPv4-mapped IPv6 clients (`::ffff:a.b.c.d`, e.g. declared in a PROXY
+/// protocol header) are normalized to plain IPv4 at that single point. This handler therefore does
+/// **not** re-normalize; it relies on that contract so `ip_filter`, the rate-limit key and
+/// `X-Forwarded-For` all observe one consistent form.
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_proxy_request(
     mut req: Request<Incoming>,

--- a/huginn-proxy-lib/src/proxy/peer_resolution.rs
+++ b/huginn-proxy-lib/src/proxy/peer_resolution.rs
@@ -145,8 +145,8 @@ fn peer_from_read_result(
 ///
 /// The returned peer is always plain IPv4 when the client arrives as an IPv4-mapped IPv6 address
 /// (`::ffff:a.b.c.d`, e.g. declared that way in a PROXY header). Canonicalization happens at the
-/// two points an address enters — the socket peer below, and the PROXY-declared client in
-/// [`peer_from_read_result`] — so every trust check, fallback and return shares one form and
+/// two points an address enters: the socket peer below, and the PROXY-declared client in
+/// `peer_from_read_result`; every trust check, fallback and return shares one form and
 /// downstream consumers (SYN probe, IP filter, rate limit, `X-Forwarded-For`) must not re-normalize.
 pub async fn resolve_peer(
     proxy_mode: ProxyProtocolMode,

--- a/huginn-proxy-lib/src/proxy/peer_resolution.rs
+++ b/huginn-proxy-lib/src/proxy/peer_resolution.rs
@@ -40,6 +40,11 @@ fn is_trusted(peer_ip: std::net::IpAddr, trusted_proxies: &TrustedProxiesConfig)
     trusted_proxies.trusts(&peer_ip)
 }
 
+/// Collapse an IPv4-mapped IPv6 peer (`::ffff:a.b.c.d`) to plain IPv4, preserving the port.
+fn canonical_peer(peer: SocketAddr) -> SocketAddr {
+    SocketAddr::new(normalize_mapped_ipv4(peer.ip()), peer.port())
+}
+
 /// Whether a passthrough outcome (non-`Require` mode, no PROXY source available) is worth
 /// recording. An untrusted peer passing through is the common, unremarkable case when
 /// `proxy_protocol=optional` serves both proxied and direct clients, so it stays silent; a
@@ -96,7 +101,7 @@ fn peer_from_read_result(
                 real_client = %src,
                 "PROXY header: real client recovered"
             );
-            Some(src)
+            Some(canonical_peer(src))
         }
         Ok(Ok(ProxySource::Local)) => {
             metrics.record_proxy_protocol_passthrough();
@@ -137,6 +142,12 @@ fn peer_from_read_result(
 /// Security boundary: a PROXY header is parsed **only** when the immediate socket peer is in
 /// `trusted_proxies`. Untrusted peers are never parsed, so a direct attacker cannot forge a
 /// header to spoof its source (classic PROXY-protocol spoofing).
+///
+/// The returned peer is always plain IPv4 when the client arrives as an IPv4-mapped IPv6 address
+/// (`::ffff:a.b.c.d`, e.g. declared that way in a PROXY header). Canonicalization happens at the
+/// two points an address enters — the socket peer below, and the PROXY-declared client in
+/// [`peer_from_read_result`] — so every trust check, fallback and return shares one form and
+/// downstream consumers (SYN probe, IP filter, rate limit, `X-Forwarded-For`) must not re-normalize.
 pub async fn resolve_peer(
     proxy_mode: ProxyProtocolMode,
     timeout_dur: Duration,
@@ -145,13 +156,14 @@ pub async fn resolve_peer(
     stream: &mut TcpStream,
     socket_peer: SocketAddr,
 ) -> Option<SocketAddr> {
+    let socket_peer = canonical_peer(socket_peer);
+
     let mode = match proxy_mode {
         ProxyProtocolMode::Off => return Some(socket_peer),
         mode => mode,
     };
 
-    let peer_ip = normalize_mapped_ipv4(socket_peer.ip());
-    if !is_trusted(peer_ip, trusted_proxies) {
+    if !is_trusted(socket_peer.ip(), trusted_proxies) {
         return require_drops(
             mode,
             metrics,

--- a/huginn-proxy-lib/src/proxy/protocol/mod.rs
+++ b/huginn-proxy-lib/src/proxy/protocol/mod.rs
@@ -85,11 +85,15 @@ pub enum ProxySource {
 
 /// Normalize an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) to plain IPv4.
 ///
-/// A dual-stack listener bound to `[::]` reports an incoming IPv4 connection with an
-/// IPv4-mapped IPv6 peer address. The `trusted_proxies` gate matches the peer against configured
-/// CIDRs, and an `IpNet::V4` entry does **not** contain an `IpAddr::V6`, so without this the
-/// trust check silently fails for an IPv4 proxy on a dual-stack listener and the whole feature
-/// degrades to `off`. Applied to the peer IP before the trust check. Mirrors rust-rpxy.
+/// An IPv4 client can surface as an IPv4-mapped IPv6 address — a dual-stack listener bound to
+/// `[::]`, or (more relevant here, since our listener forces `IPV6_V6ONLY`) a client declared that
+/// way in a PROXY protocol header by a downstream L4 proxy. Left as-is, an `IpNet::V4` entry never
+/// contains an `IpAddr::V6`, so `trusted_proxies`/`ip_filter` matches silently fail and the
+/// rate-limit key splits from the equivalent native-IPv4 peer.
+///
+/// Used in two spots: on the socket peer before the `trusted_proxies` trust check, and on the
+/// effective peer returned by `resolve_peer` (the single canonicalization point for everything
+/// downstream). Mirrors rust-rpxy.
 pub fn normalize_mapped_ipv4(addr: IpAddr) -> IpAddr {
     match addr {
         IpAddr::V6(v6) => match v6.to_ipv4_mapped() {

--- a/huginn-proxy-lib/src/proxy/protocol/mod.rs
+++ b/huginn-proxy-lib/src/proxy/protocol/mod.rs
@@ -85,7 +85,7 @@ pub enum ProxySource {
 
 /// Normalize an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`) to plain IPv4.
 ///
-/// An IPv4 client can surface as an IPv4-mapped IPv6 address — a dual-stack listener bound to
+/// An IPv4 client can surface as an IPv4-mapped IPv6 address, a dual-stack listener bound to
 /// `[::]`, or (more relevant here, since our listener forces `IPV6_V6ONLY`) a client declared that
 /// way in a PROXY protocol header by a downstream L4 proxy. Left as-is, an `IpNet::V4` entry never
 /// contains an `IpAddr::V6`, so `trusted_proxies`/`ip_filter` matches silently fail and the

--- a/huginn-proxy-lib/tests/config/audit/aggregate.rs
+++ b/huginn-proxy-lib/tests/config/audit/aggregate.rs
@@ -1,8 +1,8 @@
 use std::fs;
 
 use huginn_proxy_lib::config::{
-    all_warnings, header_config_warnings, load_from_path, security_override_warnings,
-    trusted_proxies_warnings,
+    all_warnings, header_config_warnings, load_from_path, rate_limit_warnings,
+    security_override_warnings, trusted_proxies_warnings,
 };
 
 use crate::config::tmp_path;
@@ -42,6 +42,7 @@ enabled = false
     let cfg = load_from_path(&path)?;
 
     let expected = header_config_warnings(&cfg).len()
+        + rate_limit_warnings(&cfg).len()
         + security_override_warnings(&cfg).len()
         + trusted_proxies_warnings(&cfg).len();
     let all = all_warnings(&cfg);

--- a/huginn-proxy-lib/tests/config/audit/mod.rs
+++ b/huginn-proxy-lib/tests/config/audit/mod.rs
@@ -1,5 +1,6 @@
 mod aggregate;
 mod headers;
 mod proxy_protocol;
+mod rate_limit;
 mod security_overrides;
 mod trusted_proxies;

--- a/huginn-proxy-lib/tests/config/audit/rate_limit.rs
+++ b/huginn-proxy-lib/tests/config/audit/rate_limit.rs
@@ -59,6 +59,54 @@ window_seconds = 0
 }
 
 #[test]
+fn warns_when_limit_by_header_without_header_name() -> TestResult {
+    let path = tmp_path("rl-header-missing");
+    let toml = r#"
+listen = { addrs = ["127.0.0.1:0"] }
+backends = [{ address = "backend:9000" }]
+
+[security.rate_limit]
+enabled = true
+limit_by = "header"
+"#;
+    fs::write(&path, toml)?;
+    let cfg = load_from_path(&path)?;
+
+    let warnings = rate_limit_warnings(&cfg);
+    assert_eq!(warnings.len(), 1, "expected one finding, got: {warnings:?}");
+    assert_eq!(warnings[0].scope, "global rate_limit");
+    assert!(warnings[0].message.contains("limit_by_header"));
+
+    let _ = fs::remove_file(&path);
+    Ok(())
+}
+
+#[test]
+fn silent_when_limit_by_header_has_name() -> TestResult {
+    let path = tmp_path("rl-header-ok");
+    let toml = r#"
+listen = { addrs = ["127.0.0.1:0"] }
+backends = [{ address = "backend:9000" }]
+
+[security.rate_limit]
+enabled = true
+limit_by = "header"
+limit_by_header = "X-Api-Key"
+"#;
+    fs::write(&path, toml)?;
+    let cfg = load_from_path(&path)?;
+
+    assert!(
+        rate_limit_warnings(&cfg).is_empty(),
+        "a configured header name must not warn: {:?}",
+        rate_limit_warnings(&cfg)
+    );
+
+    let _ = fs::remove_file(&path);
+    Ok(())
+}
+
+#[test]
 fn silent_when_disabled_or_positive_window() -> TestResult {
     let path = tmp_path("rl-ok");
     // Disabled block with a zero window (inert), and an enabled block with a valid window.

--- a/huginn-proxy-lib/tests/config/audit/rate_limit.rs
+++ b/huginn-proxy-lib/tests/config/audit/rate_limit.rs
@@ -1,0 +1,92 @@
+use std::fs;
+
+use huginn_proxy_lib::config::{load_from_path, rate_limit_warnings};
+
+use crate::config::tmp_path;
+
+type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+
+#[test]
+fn warns_on_enabled_rate_limit_with_zero_window() -> TestResult {
+    let path = tmp_path("rl-zero-window");
+    let toml = r#"
+listen = { addrs = ["127.0.0.1:0"] }
+backends = [{ address = "backend:9000" }]
+
+[security.rate_limit]
+enabled = true
+window_seconds = 0
+"#;
+    fs::write(&path, toml)?;
+    let cfg = load_from_path(&path)?;
+
+    let warnings = rate_limit_warnings(&cfg);
+    assert_eq!(warnings.len(), 1, "expected one finding, got: {warnings:?}");
+    assert_eq!(warnings[0].scope, "global rate_limit");
+    assert!(warnings[0].message.contains("window_seconds"));
+
+    let _ = fs::remove_file(&path);
+    Ok(())
+}
+
+#[test]
+fn warns_per_scope_for_zero_window() -> TestResult {
+    let path = tmp_path("rl-zero-window-route");
+    let toml = r#"
+listen = { addrs = ["127.0.0.1:0"] }
+backends = [{ address = "backend:9000" }]
+
+[[domains]]
+host = "api.example.com"
+
+[[domains.routes]]
+prefix = "/admin"
+backend = "backend:9000"
+
+[domains.routes.security.rate_limit]
+enabled = true
+window_seconds = 0
+"#;
+    fs::write(&path, toml)?;
+    let cfg = load_from_path(&path)?;
+
+    let warnings = rate_limit_warnings(&cfg);
+    assert_eq!(warnings.len(), 1, "expected one finding, got: {warnings:?}");
+    assert_eq!(warnings[0].scope, "route '/admin' in domain 'api.example.com' rate_limit");
+
+    let _ = fs::remove_file(&path);
+    Ok(())
+}
+
+#[test]
+fn silent_when_disabled_or_positive_window() -> TestResult {
+    let path = tmp_path("rl-ok");
+    // Disabled block with a zero window (inert), and an enabled block with a valid window.
+    let toml = r#"
+listen = { addrs = ["127.0.0.1:0"] }
+backends = [{ address = "backend:9000" }]
+
+[security.rate_limit]
+enabled = false
+window_seconds = 0
+
+[[domains]]
+host = "api.example.com"
+routes = [{ prefix = "/", backend = "backend:9000" }]
+
+[domains.security.rate_limit]
+enabled = true
+window_seconds = 1
+"#;
+    fs::write(&path, toml)?;
+    let cfg = load_from_path(&path)?;
+
+    assert!(
+        rate_limit_warnings(&cfg).is_empty(),
+        "disabled or positive-window limiters must not warn: {:?}",
+        rate_limit_warnings(&cfg)
+    );
+
+    let _ = fs::remove_file(&path);
+    Ok(())
+}

--- a/huginn-proxy-lib/tests/proxy_protocol.rs
+++ b/huginn-proxy-lib/tests/proxy_protocol.rs
@@ -11,7 +11,7 @@
 //! bytes so that the very next byte huginn reads is the TLS `0x16 0x03` record.
 
 use std::convert::Infallible;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -53,6 +53,20 @@ fn proxy_v2_ipv4(src: SocketAddrV4, dst: SocketAddrV4) -> Vec<u8> {
     buf.extend_from_slice(&dst.ip().octets());
     buf.extend_from_slice(&src.port().to_be_bytes());
     buf.extend_from_slice(&dst.port().to_be_bytes());
+    buf
+}
+
+/// Build a PROXY protocol v2 header for an IPv6 TCP `(src, dst)` pair (AF_INET6, 36-byte block).
+fn proxy_v2_ipv6(src_ip: Ipv6Addr, src_port: u16, dst_ip: Ipv6Addr, dst_port: u16) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(52);
+    buf.extend_from_slice(&V2_SIGNATURE);
+    buf.push((2 << 4) | 0x1); // version 2, command PROXY
+    buf.push((0x2 << 4) | 0x1); // AF_INET6, STREAM
+    buf.extend_from_slice(&36u16.to_be_bytes()); // address block length
+    buf.extend_from_slice(&src_ip.octets());
+    buf.extend_from_slice(&dst_ip.octets());
+    buf.extend_from_slice(&src_port.to_be_bytes());
+    buf.extend_from_slice(&dst_port.to_be_bytes());
     buf
 }
 
@@ -202,6 +216,39 @@ async fn optional_trusted_peer_header_is_applied() -> TestResult {
     assert!(
         resp.contains("xfp=51115"),
         "X-Forwarded-Port should be the PROXY-declared source port, got: {resp}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn ipv4_mapped_client_is_normalized_in_forwarded_headers() -> TestResult {
+    // A downstream LB declares the client as an IPv4-mapped IPv6 address (`::ffff:203.0.113.7`).
+    // The handler must normalize it to plain IPv4 before building X-Forwarded-For (same as the
+    // ip_filter / rate-limit key), so the backend sees `203.0.113.7`, not `::ffff:203.0.113.7`.
+    let (backend, _bh) = spawn_echo_backend().await?;
+    let port = free_port()?;
+    let (proxy, _ph) =
+        spawn_proxy(&config_toml(port, backend, "optional", "\"127.0.0.1/32\", \"::1/128\""))
+            .await?;
+
+    let src_v4 = Ipv4Addr::new(203, 0, 113, 7);
+    let header = proxy_v2_ipv6(
+        src_v4.to_ipv6_mapped(),
+        51115,
+        Ipv4Addr::new(127, 0, 0, 1).to_ipv6_mapped(),
+        port,
+    );
+
+    let resp = raw_request(proxy, &header).await;
+
+    assert!(resp.contains("200"), "expected a 200 response, got: {resp}");
+    assert!(
+        resp.contains("xff=203.0.113.7"),
+        "IPv4-mapped client must be normalized to plain IPv4 in X-Forwarded-For, got: {resp}"
+    );
+    assert!(
+        !resp.contains("::ffff:"),
+        "X-Forwarded-For must not carry the IPv4-mapped form, got: {resp}"
     );
     Ok(())
 }


### PR DESCRIPTION
### Rate-limit validation (non-fatal audit warnings)
Extend the config audit with two rate-limit checks, surfaced by `--validate` and counted by `--validate --strict`:
- Warn when a rate limit is **enabled but `window_seconds = 0`**, the limiter  can't compute a rate, so it silently never limits.
- Warn when `limit_by = "header"` but **`limit_by_header` is empty**, the limiter  silently falls back to client-IP keying instead of the intended header.


### Canonical peer normalization (single source of truth)
Move IPv4-mapped IPv6 normalization (`::ffff:a.b.c.d` → plain IPv4) into `resolve_peer`, canonicalizing at the two points an address enters: the socket peer (shadowed up front, so the trust check, fallbacks and the `off` path all use
one form) and the PROXY-declared client (in `peer_from_read_result`, where it's produced). The handler no longer re-normalizes and now relies on that contract.
This removes the duplicated normalization and closes a latent gap: `syn_probe` runs before the handler in the accept loop, so an IPv4-mapped effective peer (e.g. a client declared as `AF_INET6` mapped in a PROXY header) previously hit the wrong eBPF map family (`lookup_v6` vs `lookup`) and silently missed the TCP fingerprint.
Now every consumer  ( SYN probe, IP filter, rate-limit key, `X-Forwarded-For`) shares one canonical peer.
