### PR TITLE
allow-wildcard-paths - audit fixed

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,9 +23,9 @@ confidence-threshold = 1.0
 
 [bans]
 wildcards = "deny"
-skip = [
-    { crate = "huginn-ebpf", reason = "workspace deps for huginn-ebpf-common" },
-]
+# Path-only workspace deps (`{ path = "..." }` / `{ workspace = true }`) look like
+# `*` to cargo-deny; allow those while still denying registry wildcards.
+allow-wildcard-paths = true
 
 [sources]
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
Just adding allow-wildcard-paths in audit report