### PR TITLE
update huginn-net + improve TCP SYN signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -253,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,9 +341,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -402,7 +408,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -428,9 +434,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -491,9 +497,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -668,7 +674,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -732,9 +738,9 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -828,7 +834,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -906,9 +912,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1070,9 +1076,9 @@ version = "0.0.4-beta.0"
 
 [[package]]
 name = "huginn-net-http"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1207bab2896b2b5cda3b0f23bbe994e6deb085b7e4537384a995a79a02541855"
+checksum = "b196d02f55492562e26f713c3ce5cf26a6bb0d1857f431f3679a6b5db185eb91"
 dependencies = [
  "crossbeam-channel",
  "hpack-patched",
@@ -1087,9 +1093,9 @@ dependencies = [
 
 [[package]]
 name = "huginn-net-tcp"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d8531575ab38ca4626a8ec9846865c3f183e1c0b00e119831662c33beff5a5"
+checksum = "228ba01c3c31bafa9197ea44c7b05e57f32e0729c0e5966d96f6bcdcc3b2385e"
 dependencies = [
  "crossbeam-channel",
  "pcap-file",
@@ -1100,9 +1106,9 @@ dependencies = [
 
 [[package]]
 name = "huginn-net-tls"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0432d73ce496924dae6bb35ece0ffe6c52745897bb8e9f15fb303a8f930f1478"
+checksum = "2a080695d07c4005482377758c7593915a39c14275a6f8b15df53ec03371964e"
 dependencies = [
  "crossbeam-channel",
  "pcap-file",
@@ -1182,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1223,7 +1229,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1349,9 +1355,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1532,9 +1538,9 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -1616,9 +1622,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1913,11 +1919,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -1953,7 +1959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -2290,9 +2296,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -2380,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
 dependencies = [
  "pem",
  "ring",
@@ -2447,7 +2453,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2703,7 +2709,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2741,7 +2747,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2775,7 +2781,7 @@ checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2915,9 +2921,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3017,7 +3023,7 @@ checksum = "28b596eb866a1a2bac3e8e17080b8f21739e1bdb0b5479fe5c70d14375362a92"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "const_format",
@@ -3091,7 +3097,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3206,7 +3212,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4002,7 +4008,7 @@ checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ huginn-certs = { path = "huginn-certs" }
 huginn-ebpf = { path = "huginn-ebpf" }
 huginn-ebpf-common = { path = "huginn-ebpf-common" }
 huginn-ebpf-rate-limit = { path = "huginn-ebpf-rate-limit" }
-huginn-net-http = { version = "2.0.0", features = ["akamai"] }
-huginn-net-tcp = { version = "2.0.0", features = ["syn"] }
-huginn-net-tls = { version = "2.0.0", features = ["stable-v1"] }
+huginn-net-http = { version = "2.1.0", features = ["akamai"] }
+huginn-net-tcp = { version = "2.1.0", features = ["syn"] }
+huginn-net-tls = { version = "2.1.0", features = ["stable-v1"] }
 huginn-proxy-lib = { path = "huginn-proxy-lib" }
-hyper = { version = "1.11.0", features = ["full"] }
+hyper = { version = "1.11.1", features = ["full"] }
 hyper-util = { version = "0.1.20", features = ["full"] }
 ipnet = "2.12.1"
 libc = "0.2.189"
@@ -57,7 +57,7 @@ pingora-limits = "0.8.1"
 pingora-timeout = "0.8.1"
 ppp = "2.3.0"
 prometheus = "0.14.0"
-rcgen = "0.14.9"
+rcgen = "0.14.10"
 reqwest = { version = "0.13.4", features = ["json", "http2"] }
 rustls-pki-types = "1.15.1"
 serde = { version = "1.0.229", features = ["derive"] }

--- a/huginn-ebpf-common/src/headers.rs
+++ b/huginn-ebpf-common/src/headers.rs
@@ -106,10 +106,28 @@ impl TcpHdr {
     pub fn cwr(&self) -> bool {
         (self.offset_flags >> 15) & 1 != 0
     }
+    #[inline(always)]
+    pub fn fin(&self) -> bool {
+        (self.offset_flags >> 8) & 1 != 0
+    }
+    #[inline(always)]
+    pub fn rst(&self) -> bool {
+        (self.offset_flags >> 10) & 1 != 0
+    }
     /// ECN Nonce Sum (RFC 3540), bit 3 of the low byte.
     #[inline(always)]
     pub fn ns(&self) -> bool {
         (self.offset_flags >> 3) & 1 != 0
+    }
+
+    /// p0f capture predicate: `flags & (SYN|ACK|FIN|RST) == SYN`.
+    ///
+    /// Mirrors huginn-net's `is_valid` + `is_fingerprintable`, which discard the
+    /// SYN+FIN / SYN+RST combinations that scanners emit. Without the FIN/RST
+    /// check a crafted packet yields a fingerprint the reference never produces.
+    #[inline(always)]
+    pub fn is_bare_syn(&self) -> bool {
+        self.syn() && !self.ack() && !self.fin() && !self.rst()
     }
 }
 

--- a/huginn-ebpf-common/src/headers.rs
+++ b/huginn-ebpf-common/src/headers.rs
@@ -144,4 +144,13 @@ impl Ip6Hdr {
     pub fn traffic_class(&self) -> u8 {
         ((self.priority_version & 0x0F) << 4) | ((self.flow_lbl[0] & 0xF0) >> 4)
     }
+
+    /// Whether the 20-bit IPv6 flow label is non-zero (p0f `flow` quirk).
+    ///
+    /// Layout: `flow_lbl[0]` low nibble is the high 4 bits of the label; `[1]` and `[2]`
+    /// are the remaining 16 bits.
+    #[inline(always)]
+    pub fn flow_label_nonzero(&self) -> bool {
+        (self.flow_lbl[0] & 0x0F) != 0 || self.flow_lbl[1] != 0 || self.flow_lbl[2] != 0
+    }
 }

--- a/huginn-ebpf-common/src/quirk_bits.rs
+++ b/huginn-ebpf-common/src/quirk_bits.rs
@@ -11,6 +11,7 @@ pub const NONZERO_URG: u32 = 1 << 7;
 pub const URG: u32 = 1 << 8;
 pub const PUSH: u32 = 1 << 9;
 pub const NS: u32 = 1 << 10; // ECN Nonce Sum (RFC 3540)
+pub const FLOW: u32 = 1 << 11; // IPv6 non-zero flow label (p0f `flow`)
 
 use crate::constants::{IP_DF, IP_RF, IP_TOS_CE, IP_TOS_ECT};
 use crate::headers::{Ip4Hdr, Ip6Hdr, TcpHdr};
@@ -46,11 +47,11 @@ pub fn compute_v4(ip: &Ip4Hdr, tcp: &TcpHdr) -> u32 {
     if tcp.ack_seq != 0 {
         quirks |= ACK_NONZERO;
     }
-    if tcp.urg_ptr != 0 {
-        quirks |= NONZERO_URG;
-    }
+    // p0f / huginn-net: URG flag and uptr+ are mutually exclusive.
     if tcp.urg() {
         quirks |= URG;
+    } else if tcp.urg_ptr != 0 {
+        quirks |= NONZERO_URG;
     }
     if tcp.psh() {
         quirks |= PUSH;
@@ -65,8 +66,8 @@ pub fn compute_v4(ip: &Ip4Hdr, tcp: &TcpHdr) -> u32 {
 ///
 /// IPv6-specific: `DF`, `NONZERO_ID`, `ZERO_ID`, `MUST_BE_ZERO` are never set
 /// (they depend on IPv4 `id`/`frag_off` fields absent in IPv6). `ECN` is derived
-/// from the traffic class byte and TCP ECE/CWR. All TCP-level quirks are identical
-/// to the IPv4 path.
+/// from the traffic class byte and TCP ECE/CWR. `FLOW` is set when the flow label
+/// is non-zero. All TCP-level quirks are identical to the IPv4 path.
 ///
 /// Pure function: no packet or map access. Safe to call on host with mock headers.
 #[inline(always)]
@@ -74,6 +75,9 @@ pub fn compute_v6(ip6: &Ip6Hdr, tcp: &TcpHdr) -> u32 {
     let mut quirks: u32 = 0;
     let tc = ip6.traffic_class();
 
+    if ip6.flow_label_nonzero() {
+        quirks |= FLOW;
+    }
     if tcp.ece() || tcp.cwr() || (tc & (IP_TOS_CE | IP_TOS_ECT) != 0) {
         quirks |= ECN;
     }
@@ -83,11 +87,11 @@ pub fn compute_v6(ip6: &Ip6Hdr, tcp: &TcpHdr) -> u32 {
     if tcp.ack_seq != 0 {
         quirks |= ACK_NONZERO;
     }
-    if tcp.urg_ptr != 0 {
-        quirks |= NONZERO_URG;
-    }
+    // p0f / huginn-net: URG flag and uptr+ are mutually exclusive.
     if tcp.urg() {
         quirks |= URG;
+    } else if tcp.urg_ptr != 0 {
+        quirks |= NONZERO_URG;
     }
     if tcp.psh() {
         quirks |= PUSH;

--- a/huginn-ebpf-common/src/quirk_bits.rs
+++ b/huginn-ebpf-common/src/quirk_bits.rs
@@ -1,4 +1,7 @@
 //! Quirk bitmask constants and computation for TCP SYN fingerprinting (p0f-style).
+//!
+//! The bitmask also carries `PAYLOAD_NONZERO`, which is not a quirk but the p0f
+//! `pclass` field. It rides along here so the BPF map value layout stays fixed.
 
 pub const DF: u32 = 1 << 0;
 pub const NONZERO_ID: u32 = 1 << 1;
@@ -12,6 +15,9 @@ pub const URG: u32 = 1 << 8;
 pub const PUSH: u32 = 1 << 9;
 pub const NS: u32 = 1 << 10; // ECN Nonce Sum (RFC 3540)
 pub const FLOW: u32 = 1 << 11; // IPv6 non-zero flow label (p0f `flow`)
+
+/// Not a quirk: the SYN carries payload (TCP Fast Open), i.e. p0f `pclass` == `+`.
+pub const PAYLOAD_NONZERO: u32 = 1 << 12;
 
 use crate::constants::{IP_DF, IP_RF, IP_TOS_CE, IP_TOS_ECT};
 use crate::headers::{Ip4Hdr, Ip6Hdr, TcpHdr};
@@ -59,6 +65,14 @@ pub fn compute_v4(ip: &Ip4Hdr, tcp: &TcpHdr) -> u32 {
     if tcp.ns() {
         quirks |= NS;
     }
+    // p0f `pclass`: a SYN with data (TCP Fast Open) is `+`. A `tot_len` shorter than
+    // the headers (or zeroed by offload) falls back to "no payload".
+    let hdr_bytes = u16::from(ip.ihl())
+        .saturating_mul(4)
+        .saturating_add(u16::from(tcp.doff()).saturating_mul(4));
+    if u16::from_be(ip.tot_len) > hdr_bytes {
+        quirks |= PAYLOAD_NONZERO;
+    }
     quirks
 }
 
@@ -98,6 +112,11 @@ pub fn compute_v6(ip6: &Ip6Hdr, tcp: &TcpHdr) -> u32 {
     }
     if tcp.ns() {
         quirks |= NS;
+    }
+    // p0f `pclass`. Only nexthdr == TCP is captured, so `payload_len` holds no
+    // extension headers and the TCP header is all that precedes the payload.
+    if u16::from_be(ip6.payload_len) > u16::from(tcp.doff()).saturating_mul(4) {
+        quirks |= PAYLOAD_NONZERO;
     }
     quirks
 }

--- a/huginn-ebpf-common/src/syn_raw_v4.rs
+++ b/huginn-ebpf-common/src/syn_raw_v4.rs
@@ -11,7 +11,7 @@
 //! offset 10: ip_ttl    u8
 //! offset 11: ip_olen   u8   (IP options length: ihl*4 - 20)
 //! offset 12: options   [u8; 40]
-//! offset 52: quirks    u32  (quirk_bits bitmask)
+//! offset 52: quirks    u32  (quirk_bits bitmask; also carries PAYLOAD_NONZERO -> pclass)
 //! offset 56: tick      u64  (global SYN counter at capture time)
 //! total: 64 bytes
 //! ```

--- a/huginn-ebpf-common/src/syn_raw_v6.rs
+++ b/huginn-ebpf-common/src/syn_raw_v6.rs
@@ -12,7 +12,8 @@
 //! offset 23: _pad      u8        (always 0; ip_olen has no IPv6 equivalent)
 //! offset 24: options   [u8; 40]
 //! offset 64: quirks    u32       (quirk_bits bitmask; DF/ID quirks absent for IPv6;
-//!                                 FLOW set when flow label != 0)
+//!                                 FLOW set when flow label != 0; also carries
+//!                                 PAYLOAD_NONZERO -> pclass)
 //! offset 68: tick      u64       (global SYN counter at capture time; shared with V4)
 //! total: 76 bytes
 //! ```

--- a/huginn-ebpf-common/src/syn_raw_v6.rs
+++ b/huginn-ebpf-common/src/syn_raw_v6.rs
@@ -11,7 +11,8 @@
 //! offset 22: ip_ttl    u8        (IPv6 hop_limit)
 //! offset 23: _pad      u8        (always 0; ip_olen has no IPv6 equivalent)
 //! offset 24: options   [u8; 40]
-//! offset 64: quirks    u32       (quirk_bits bitmask; DF/ID quirks absent for IPv6)
+//! offset 64: quirks    u32       (quirk_bits bitmask; DF/ID quirks absent for IPv6;
+//!                                 FLOW set when flow label != 0)
 //! offset 68: tick      u64       (global SYN counter at capture time; shared with V4)
 //! total: 76 bytes
 //! ```

--- a/huginn-ebpf-common/tests/compute_quirks.rs
+++ b/huginn-ebpf-common/tests/compute_quirks.rs
@@ -16,7 +16,7 @@ fn ip4(frag_off: u16, id: u16, tos: u8) -> Ip4Hdr {
     Ip4Hdr {
         version_ihl: 0x45,
         tos,
-        tot_len: 60,
+        tot_len: 60_u16.to_be(),
         id,
         frag_off,
         ttl: 64,
@@ -36,7 +36,7 @@ fn ip6_with_flow(priority_version: u8, flow_lbl: [u8; 3]) -> Ip6Hdr {
     Ip6Hdr {
         priority_version,
         flow_lbl,
-        payload_len: 40,
+        payload_len: 40_u16.to_be(),
         nexthdr: 6,
         hop_limit: 64,
         saddr: [0u8; 16],
@@ -304,4 +304,52 @@ fn v6_zero_flow_label_no_flow_quirk() {
     // tc nibble in high half of flow_lbl[0] must not count as flow label.
     let q = compute_v6(&ip6(0x60, 0xF0), &syn_tcp());
     assert_eq!(q & quirk_bits::FLOW, 0);
+}
+
+// ── pclass (PAYLOAD_NONZERO) ─────────────────────────────────────────────────
+
+#[test]
+fn v4_bare_syn_has_no_payload() {
+    // tot_len 60 == ihl(5)*4 + doff(10)*4.
+    let q = compute_v4(&ip4(IP_DF, 1234, 0), &syn_tcp());
+    assert_eq!(q & quirk_bits::PAYLOAD_NONZERO, 0);
+}
+
+#[test]
+fn v4_syn_with_data_sets_payload_nonzero() {
+    let mut ip = ip4(IP_DF, 1234, 0);
+    ip.tot_len = 61_u16.to_be();
+    let q = compute_v4(&ip, &syn_tcp());
+    assert_ne!(q & quirk_bits::PAYLOAD_NONZERO, 0);
+}
+
+#[test]
+fn v4_tot_len_shorter_than_headers_has_no_payload() {
+    let mut ip = ip4(IP_DF, 1234, 0);
+    ip.tot_len = 40_u16.to_be();
+    let q = compute_v4(&ip, &syn_tcp());
+    assert_eq!(q & quirk_bits::PAYLOAD_NONZERO, 0);
+}
+
+#[test]
+fn v4_zeroed_tot_len_has_no_payload() {
+    let mut ip = ip4(IP_DF, 1234, 0);
+    ip.tot_len = 0;
+    let q = compute_v4(&ip, &syn_tcp());
+    assert_eq!(q & quirk_bits::PAYLOAD_NONZERO, 0);
+}
+
+#[test]
+fn v6_bare_syn_has_no_payload() {
+    // payload_len 40 == doff(10)*4.
+    let q = compute_v6(&ip6(0x60, 0x00), &syn_tcp());
+    assert_eq!(q & quirk_bits::PAYLOAD_NONZERO, 0);
+}
+
+#[test]
+fn v6_syn_with_data_sets_payload_nonzero() {
+    let mut ip = ip6(0x60, 0x00);
+    ip.payload_len = 41_u16.to_be();
+    let q = compute_v6(&ip, &syn_tcp());
+    assert_ne!(q & quirk_bits::PAYLOAD_NONZERO, 0);
 }

--- a/huginn-ebpf-common/tests/compute_quirks.rs
+++ b/huginn-ebpf-common/tests/compute_quirks.rs
@@ -29,9 +29,13 @@ fn ip4(frag_off: u16, id: u16, tos: u8) -> Ip4Hdr {
 
 /// Baseline IPv6 header. `priority_version` encodes version=6 + tc_high.
 fn ip6(priority_version: u8, flow_lbl_0: u8) -> Ip6Hdr {
+    ip6_with_flow(priority_version, [flow_lbl_0, 0, 0])
+}
+
+fn ip6_with_flow(priority_version: u8, flow_lbl: [u8; 3]) -> Ip6Hdr {
     Ip6Hdr {
         priority_version,
-        flow_lbl: [flow_lbl_0, 0, 0],
+        flow_lbl,
         payload_len: 40,
         nexthdr: 6,
         hop_limit: 64,
@@ -185,6 +189,15 @@ fn v4_urg_flag() {
 }
 
 #[test]
+fn v4_urg_flag_with_nonzero_ptr_excludes_uptr() {
+    // p0f: when URG is set, only urgf+ — not uptr+ even if urg_ptr != 0.
+    let t = tcp(0x0200 | 0x00A0 | 0x2000, 0, 0, 1);
+    let q = compute_v4(&ip4(IP_DF, 1, 0), &t);
+    assert_ne!(q & quirk_bits::URG, 0);
+    assert_eq!(q & quirk_bits::NONZERO_URG, 0);
+}
+
+#[test]
 fn v4_push_flag() {
     // PSH flag = bit 11 = 0x0800
     let t = tcp(0x0200 | 0x00A0 | 0x0800, 0, 0, 0);
@@ -271,4 +284,24 @@ fn v6_clean_syn_has_no_quirks() {
     let t = tcp(0x0200 | 0x00A0, 1, 0, 0);
     let q = compute_v6(&ip6(0x60, 0x00), &t);
     assert_eq!(q, 0, "clean IPv6 SYN should produce no quirks, got {q:#010x}");
+}
+
+#[test]
+fn v6_flow_label_sets_flow() {
+    // flow_lbl[0] low nibble = high 4 bits of the 20-bit label.
+    let q = compute_v6(&ip6_with_flow(0x60, [0x01, 0, 0]), &syn_tcp());
+    assert_ne!(q & quirk_bits::FLOW, 0);
+}
+
+#[test]
+fn v6_flow_label_mid_byte_sets_flow() {
+    let q = compute_v6(&ip6_with_flow(0x60, [0x00, 0x01, 0]), &syn_tcp());
+    assert_ne!(q & quirk_bits::FLOW, 0);
+}
+
+#[test]
+fn v6_zero_flow_label_no_flow_quirk() {
+    // tc nibble in high half of flow_lbl[0] must not count as flow label.
+    let q = compute_v6(&ip6(0x60, 0xF0), &syn_tcp());
+    assert_eq!(q & quirk_bits::FLOW, 0);
 }

--- a/huginn-ebpf-common/tests/headers.rs
+++ b/huginn-ebpf-common/tests/headers.rs
@@ -80,6 +80,37 @@ fn tcp_ack_flag() {
 }
 
 #[test]
+fn tcp_fin_flag() {
+    // FIN = bit 8 = 0x0100
+    assert!(tcp_hdr(0x0100).fin());
+    assert!(!tcp_hdr(0x0000).fin());
+    assert!(!tcp_hdr(0x0200).fin()); // SYN only
+}
+
+#[test]
+fn tcp_rst_flag() {
+    // RST = bit 10 = 0x0400
+    assert!(tcp_hdr(0x0400).rst());
+    assert!(!tcp_hdr(0x0000).rst());
+}
+
+/// Mirrors huginn-net `is_valid` + `is_fingerprintable`: only a bare SYN is captured.
+#[test]
+fn tcp_is_bare_syn_matches_reference_filter() {
+    assert!(tcp_hdr(0x0200).is_bare_syn(), "plain SYN must be captured");
+    // PSH/URG/ECE/CWR are outside p0f's tcp_type mask, so they stay fingerprintable.
+    assert!(tcp_hdr(0x0200 | 0x0800).is_bare_syn(), "SYN+PSH must be captured");
+    assert!(tcp_hdr(0x0200 | 0x2000).is_bare_syn(), "SYN+URG must be captured");
+    assert!(tcp_hdr(0x0200 | 0xC000).is_bare_syn(), "SYN+ECE+CWR must be captured");
+
+    assert!(!tcp_hdr(0x0000).is_bare_syn(), "no SYN");
+    assert!(!tcp_hdr(0x1200).is_bare_syn(), "SYN+ACK is the server side");
+    assert!(!tcp_hdr(0x0300).is_bare_syn(), "SYN+FIN is rejected by huginn-net");
+    assert!(!tcp_hdr(0x0600).is_bare_syn(), "SYN+RST is rejected by huginn-net");
+    assert!(!tcp_hdr(0x0700).is_bare_syn(), "SYN+FIN+RST is rejected by huginn-net");
+}
+
+#[test]
 fn tcp_syn_ack_combined() {
     // SYN+ACK = 0x1200
     let h = tcp_hdr(0x1200);

--- a/huginn-ebpf-common/tests/headers.rs
+++ b/huginn-ebpf-common/tests/headers.rs
@@ -165,3 +165,16 @@ fn ip6_traffic_class_dscp46_ecn0() {
     // priority_version = 0x6B, flow_lbl[0] = 0x80
     assert_eq!(ip6_hdr(0x6B, 0x80).traffic_class(), 0xB8);
 }
+
+// ── Ip6Hdr::flow_label_nonzero ───────────────────────────────────────────────
+
+#[test]
+fn ip6_flow_label_zero() {
+    // tc nibble alone must not count as flow label.
+    assert!(!ip6_hdr(0x60, 0xF0).flow_label_nonzero());
+}
+
+#[test]
+fn ip6_flow_label_high_nibble() {
+    assert!(ip6_hdr(0x60, 0x01).flow_label_nonzero());
+}

--- a/huginn-ebpf-common/tests/quirk_bits.rs
+++ b/huginn-ebpf-common/tests/quirk_bits.rs
@@ -16,6 +16,7 @@ fn quirk_bits_expected_values() {
     assert_eq!(quirk_bits::PUSH, 1 << 9);
     assert_eq!(quirk_bits::NS, 1 << 10);
     assert_eq!(quirk_bits::FLOW, 1 << 11);
+    assert_eq!(quirk_bits::PAYLOAD_NONZERO, 1 << 12);
 }
 
 #[test]
@@ -33,6 +34,7 @@ fn quirk_bits_all_distinct() {
         quirk_bits::PUSH,
         quirk_bits::NS,
         quirk_bits::FLOW,
+        quirk_bits::PAYLOAD_NONZERO,
     ];
     for (i, &a) in bits.iter().enumerate() {
         for (j, &b) in bits.iter().enumerate() {

--- a/huginn-ebpf-common/tests/quirk_bits.rs
+++ b/huginn-ebpf-common/tests/quirk_bits.rs
@@ -15,6 +15,7 @@ fn quirk_bits_expected_values() {
     assert_eq!(quirk_bits::URG, 1 << 8);
     assert_eq!(quirk_bits::PUSH, 1 << 9);
     assert_eq!(quirk_bits::NS, 1 << 10);
+    assert_eq!(quirk_bits::FLOW, 1 << 11);
 }
 
 #[test]
@@ -31,6 +32,7 @@ fn quirk_bits_all_distinct() {
         quirk_bits::URG,
         quirk_bits::PUSH,
         quirk_bits::NS,
+        quirk_bits::FLOW,
     ];
     for (i, &a) in bits.iter().enumerate() {
         for (j, &b) in bits.iter().enumerate() {

--- a/huginn-ebpf-programs/Cargo.lock
+++ b/huginn-ebpf-programs/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -333,7 +333,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -350,9 +350,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]

--- a/huginn-ebpf-programs/src/signals/tcp_syn/handler.rs
+++ b/huginn-ebpf-programs/src/signals/tcp_syn/handler.rs
@@ -1,7 +1,7 @@
 use super::maps::{
     increment_syn_captured_v4, increment_syn_captured_v6, increment_syn_insert_failures_v4,
-    increment_syn_insert_failures_v6, read_and_increment_syn_counter, tcp_syn_map_v4,
-    tcp_syn_map_v6,
+    increment_syn_insert_failures_v6, increment_syn_malformed_v4, increment_syn_malformed_v6,
+    read_and_increment_syn_counter, tcp_syn_map_v4, tcp_syn_map_v6,
 };
 use aya_ebpf::programs::XdpContext;
 use core::mem;
@@ -15,6 +15,18 @@ use huginn_ebpf_common::{make_key_v4, make_key_v6, SynRawDataV4, SynRawDataV6};
 #[derive(Clone, Copy)]
 pub enum TcpSynError {
     MapInsertFailed,
+    /// Fewer option bytes readable than `doff` declares; see `declared_optlen`.
+    TruncatedOptions,
+}
+
+/// TCP option bytes the header declares. `doff` maxes out at 15, so this never
+/// exceeds `TCPOPT_MAXLEN` and the `min` is only a bound for the verifier.
+#[inline(always)]
+fn declared_optlen(tcp: &TcpHdr) -> usize {
+    usize::from(tcp.doff())
+        .saturating_mul(4)
+        .saturating_sub(mem::size_of::<TcpHdr>())
+        .min(TCPOPT_MAXLEN)
 }
 
 #[allow(unsafe_code)]
@@ -26,10 +38,7 @@ pub fn handle_tcp_syn_v4(
 ) -> Result<(), TcpSynError> {
     // Must stay inline so the BPF verifier tracks packet bounds in this frame.
     // SAFETY: tcp is valid packet memory; options start immediately after the header.
-    let tcp_hdr_len = usize::from(tcp.doff()).saturating_mul(4);
-    let declared_optlen = tcp_hdr_len
-        .saturating_sub(mem::size_of::<TcpHdr>())
-        .min(TCPOPT_MAXLEN);
+    let declared_optlen = declared_optlen(tcp);
 
     let opts_ptr = unsafe { (tcp as *const TcpHdr as *const u8).add(mem::size_of::<TcpHdr>()) };
     let data_end = ctx.data_end();
@@ -58,6 +67,13 @@ pub fn finish_tcp_syn_v4(
     options: [u8; 40],
     optlen: u8,
 ) -> Result<(), TcpSynError> {
+    // A short read would leave `optlen` below the declared length, shrinking both the
+    // option layout and `tot_hdr` relative to what huginn-net derives from `doff`.
+    if usize::from(optlen) != declared_optlen(tcp) {
+        increment_syn_malformed_v4();
+        return Err(TcpSynError::TruncatedOptions);
+    }
+
     let tick = read_and_increment_syn_counter();
     let quirks = compute_quirks_v4(ip, tcp);
 
@@ -85,10 +101,7 @@ pub fn finish_tcp_syn_v4(
 
 #[allow(unsafe_code)]
 pub fn handle_tcp_syn_v6(ctx: &XdpContext, ip6: &Ip6Hdr, tcp: &TcpHdr) -> Result<(), TcpSynError> {
-    let tcp_hdr_len = usize::from(tcp.doff()).saturating_mul(4);
-    let declared_optlen = tcp_hdr_len
-        .saturating_sub(mem::size_of::<TcpHdr>())
-        .min(TCPOPT_MAXLEN);
+    let declared_optlen = declared_optlen(tcp);
 
     let opts_ptr = unsafe { (tcp as *const TcpHdr as *const u8).add(mem::size_of::<TcpHdr>()) };
     let data_end = ctx.data_end();
@@ -115,6 +128,12 @@ pub fn finish_tcp_syn_v6(
     options: [u8; 40],
     optlen: u8,
 ) -> Result<(), TcpSynError> {
+    // See `finish_tcp_syn_v4`: a partial option read would desync `tot_hdr` from `doff`.
+    if usize::from(optlen) != declared_optlen(tcp) {
+        increment_syn_malformed_v6();
+        return Err(TcpSynError::TruncatedOptions);
+    }
+
     let tick = read_and_increment_syn_counter();
     let quirks = compute_quirks_v6(ip6, tcp);
 

--- a/huginn-ebpf-programs/src/signals/tcp_syn/mod.rs
+++ b/huginn-ebpf-programs/src/signals/tcp_syn/mod.rs
@@ -4,7 +4,9 @@ mod handler;
 mod log_level;
 mod maps;
 
-pub use handler::{finish_tcp_syn_v4, finish_tcp_syn_v6, handle_tcp_syn_v4, handle_tcp_syn_v6};
+pub use handler::{
+    finish_tcp_syn_v4, finish_tcp_syn_v6, handle_tcp_syn_v4, handle_tcp_syn_v6, TcpSynError,
+};
 pub use log_level::{level, log_level};
 pub use maps::{
     dst_ip_v4, dst_ip_v6, dst_port, increment_syn_malformed_v4, increment_syn_malformed_v6,

--- a/huginn-ebpf-programs/src/tc/mod.rs
+++ b/huginn-ebpf-programs/src/tc/mod.rs
@@ -81,7 +81,7 @@ fn handle_ipv4(ctx: &TcContext, offset: usize) {
         return;
     }
 
-    if !tcp.syn() || tcp.ack() {
+    if !tcp.is_bare_syn() {
         return;
     }
 
@@ -101,8 +101,11 @@ fn handle_ipv4(ctx: &TcContext, offset: usize) {
             u16::from_be(tcp.source),
             u16::from_be(tcp.dest)
         ),
-        Err(_) if lvl >= tcp_syn::level::WARN => {
+        Err(tcp_syn::TcpSynError::MapInsertFailed) if lvl >= tcp_syn::level::WARN => {
             warn!(ctx, "tc: TCP SYN v4 map insert failed (LRU full?)")
+        }
+        Err(tcp_syn::TcpSynError::TruncatedOptions) if lvl >= tcp_syn::level::DEBUG => {
+            debug!(ctx, "tc: TCP SYN v4 options truncated; not fingerprinted")
         }
         _ => {}
     }
@@ -140,7 +143,7 @@ fn handle_ipv6(ctx: &TcContext, offset: usize) {
         return;
     }
 
-    if !tcp.syn() || tcp.ack() {
+    if !tcp.is_bare_syn() {
         return;
     }
 
@@ -160,8 +163,11 @@ fn handle_ipv6(ctx: &TcContext, offset: usize) {
             u16::from_be(tcp.source),
             u16::from_be(tcp.dest)
         ),
-        Err(_) if lvl >= tcp_syn::level::WARN => {
+        Err(tcp_syn::TcpSynError::MapInsertFailed) if lvl >= tcp_syn::level::WARN => {
             warn!(ctx, "tc: TCP SYN v6 map insert failed (LRU full?)")
+        }
+        Err(tcp_syn::TcpSynError::TruncatedOptions) if lvl >= tcp_syn::level::DEBUG => {
+            debug!(ctx, "tc: TCP SYN v6 options truncated; not fingerprinted")
         }
         _ => {}
     }

--- a/huginn-ebpf-programs/src/xdp/mod.rs
+++ b/huginn-ebpf-programs/src/xdp/mod.rs
@@ -92,7 +92,7 @@ fn handle_ipv4(ctx: &XdpContext, mut offset: usize) {
         return;
     }
 
-    if unsafe { !(*tcp).syn() || (*tcp).ack() } {
+    if unsafe { !(*tcp).is_bare_syn() } {
         return;
     }
 
@@ -113,8 +113,11 @@ fn handle_ipv4(ctx: &XdpContext, mut offset: usize) {
             u16::from_be(tcp_ref.source),
             u16::from_be(tcp_ref.dest)
         ),
-        Err(_) if lvl >= tcp_syn::level::WARN => {
+        Err(tcp_syn::TcpSynError::MapInsertFailed) if lvl >= tcp_syn::level::WARN => {
             warn!(ctx, "xdp: TCP SYN v4 map insert failed (LRU full?)")
+        }
+        Err(tcp_syn::TcpSynError::TruncatedOptions) if lvl >= tcp_syn::level::DEBUG => {
+            debug!(ctx, "xdp: TCP SYN v4 options truncated; not fingerprinted")
         }
         _ => {}
     }
@@ -158,7 +161,7 @@ fn handle_ipv6(ctx: &XdpContext, mut offset: usize) {
         return;
     }
 
-    if unsafe { !(*tcp).syn() || (*tcp).ack() } {
+    if unsafe { !(*tcp).is_bare_syn() } {
         return;
     }
 
@@ -179,8 +182,11 @@ fn handle_ipv6(ctx: &XdpContext, mut offset: usize) {
             u16::from_be(tcp_ref.source),
             u16::from_be(tcp_ref.dest)
         ),
-        Err(_) if lvl >= tcp_syn::level::WARN => {
+        Err(tcp_syn::TcpSynError::MapInsertFailed) if lvl >= tcp_syn::level::WARN => {
             warn!(ctx, "xdp: TCP SYN v6 map insert failed (LRU full?)")
+        }
+        Err(tcp_syn::TcpSynError::TruncatedOptions) if lvl >= tcp_syn::level::DEBUG => {
+            debug!(ctx, "xdp: TCP SYN v6 options truncated; not fingerprinted")
         }
         _ => {}
     }

--- a/huginn-ebpf/src/types.rs
+++ b/huginn-ebpf/src/types.rs
@@ -36,9 +36,13 @@ fn scan_option_quirks(opts: &[u8]) -> OptionQuirks {
                 let Some(option_data) = data.get(..data_len) else {
                     break;
                 };
-                if kind == 8 && len == 10 {
-                    if let (Some(v), Some(e)) = (option_data.get(..4), option_data.get(4..8)) {
+                // huginn-net gates on the payload length (>= 4 / >= 8), not on the
+                // declared option length, so an off-spec TS length still yields ts1-/ts2+.
+                if kind == 8 {
+                    if let Some(v) = option_data.get(..4) {
                         ts_val = Some(u32::from_be_bytes([v[0], v[1], v[2], v[3]]));
+                    }
+                    if let Some(e) = option_data.get(4..8) {
                         ts_ecr = Some(u32::from_be_bytes([e[0], e[1], e[2], e[3]]));
                     }
                 }
@@ -121,6 +125,9 @@ fn decode_pclass(bits: u32) -> PayloadSize {
     }
 }
 
+/// Deliberate deviation from huginn-net: its `visit_tcp` keeps the partial layout and
+/// still emits a signature when the options are malformed. Emitting nothing avoids
+/// injecting a header whose signature cannot match any database entry.
 pub fn parse_syn_v6(raw: &SynRawDataV6) -> Option<TcpObservation> {
     let window_host = u16::from_be(raw.window);
     let optlen = raw.optlen.min(40);
@@ -159,6 +166,7 @@ pub fn parse_syn_v6(raw: &SynRawDataV6) -> Option<TcpObservation> {
     })
 }
 
+/// See [`parse_syn_v6`] for the malformed-options behaviour.
 pub fn parse_syn_v4(raw: &SynRawDataV4) -> Option<TcpObservation> {
     let window_host = u16::from_be(raw.window);
     let optlen = raw.optlen.min(40);

--- a/huginn-ebpf/src/types.rs
+++ b/huginn-ebpf/src/types.rs
@@ -113,6 +113,14 @@ fn dscp_from_tos(ip_tos: u8) -> u8 {
     ip_tos.wrapping_shr(2)
 }
 
+fn decode_pclass(bits: u32) -> PayloadSize {
+    if bits & quirk_bits::PAYLOAD_NONZERO != 0 {
+        PayloadSize::NonZero
+    } else {
+        PayloadSize::Zero
+    }
+}
+
 pub fn parse_syn_v6(raw: &SynRawDataV6) -> Option<TcpObservation> {
     let window_host = u16::from_be(raw.window);
     let optlen = raw.optlen.min(40);
@@ -145,7 +153,7 @@ pub fn parse_syn_v6(raw: &SynRawDataV6) -> Option<TcpObservation> {
         wscale: parsed.wscale,
         olayout: parsed.olayout,
         quirks,
-        pclass: PayloadSize::Zero,
+        pclass: decode_pclass(raw.quirks),
         peer_mss: None,
         tos: dscp_from_tos(raw.ip_tos),
     })
@@ -186,7 +194,7 @@ pub fn parse_syn_v4(raw: &SynRawDataV4) -> Option<TcpObservation> {
         wscale: parsed.wscale,
         olayout: parsed.olayout,
         quirks,
-        pclass: PayloadSize::Zero,
+        pclass: decode_pclass(raw.quirks),
         peer_mss: None,
         tos: dscp_from_tos(raw.ip_tos),
     })

--- a/huginn-ebpf/src/types.rs
+++ b/huginn-ebpf/src/types.rs
@@ -85,6 +85,9 @@ fn decode_quirks(bits: u32) -> QuirkSet {
     if bits & quirk_bits::PUSH != 0 {
         set.insert(Quirk::Push);
     }
+    if bits & quirk_bits::FLOW != 0 {
+        set.insert(Quirk::FlowID);
+    }
     set
 }
 
@@ -127,9 +130,7 @@ pub fn parse_syn_v6(raw: &SynRawDataV6) -> Option<TcpObservation> {
 
     let ittl: Ttl = ttl::calculate_ttl(raw.ip_ttl);
     // IPv6 fixed header (40) + TCP header including options (20 + optlen).
-    let tot_hdr = 40_u16
-        .saturating_add(20)
-        .saturating_add(u16::from(optlen));
+    let tot_hdr = 40_u16.saturating_add(20).saturating_add(u16::from(optlen));
 
     let mut quirks = decode_quirks(raw.quirks);
     apply_option_quirks(&mut quirks, valid_opts, parsed.wscale);

--- a/huginn-ebpf/src/types.rs
+++ b/huginn-ebpf/src/types.rs
@@ -1,8 +1,7 @@
 use huginn_net_tcp::syn_options::{parse_options_raw, ParsedTcpOptions};
-use huginn_net_tcp::tcp::{IpVersion, PayloadSize, TcpOption};
-use huginn_net_tcp::tcp::{Quirk, Ttl, WindowSize};
+use huginn_net_tcp::tcp::{IpVersion, PayloadSize, Quirk, QuirkSet, Ttl};
+use huginn_net_tcp::ttl;
 use huginn_net_tcp::TcpObservation;
-use huginn_net_tcp::{ttl, window_size};
 use tracing::warn;
 
 pub use huginn_ebpf_common::{quirk_bits, SynRawDataV4, SynRawDataV6};
@@ -54,44 +53,67 @@ fn scan_option_quirks(opts: &[u8]) -> OptionQuirks {
     OptionQuirks { ts_val, ts_ecr, trailing_nonzero: false }
 }
 
-fn decode_quirks(bits: u32) -> Vec<Quirk> {
-    let mut v = Vec::new();
+fn decode_quirks(bits: u32) -> QuirkSet {
+    let mut set = QuirkSet::EMPTY;
     if bits & quirk_bits::DF != 0 {
-        v.push(Quirk::Df);
+        set.insert(Quirk::Df);
     }
     if bits & quirk_bits::NONZERO_ID != 0 {
-        v.push(Quirk::NonZeroID);
+        set.insert(Quirk::NonZeroID);
     }
     if bits & quirk_bits::ZERO_ID != 0 {
-        v.push(Quirk::ZeroID);
+        set.insert(Quirk::ZeroID);
     }
     if bits & quirk_bits::MUST_BE_ZERO != 0 {
-        v.push(Quirk::MustBeZero);
+        set.insert(Quirk::MustBeZero);
     }
     if bits & quirk_bits::ECN != 0 {
-        v.push(Quirk::Ecn);
+        set.insert(Quirk::Ecn);
     }
     if bits & quirk_bits::SEQ_ZERO != 0 {
-        v.push(Quirk::SeqNumZero);
+        set.insert(Quirk::SeqNumZero);
     }
     if bits & quirk_bits::ACK_NONZERO != 0 {
-        v.push(Quirk::AckNumNonZero);
+        set.insert(Quirk::AckNumNonZero);
     }
     if bits & quirk_bits::NONZERO_URG != 0 {
-        v.push(Quirk::NonZeroURG);
+        set.insert(Quirk::NonZeroURG);
     }
     if bits & quirk_bits::URG != 0 {
-        v.push(Quirk::Urg);
+        set.insert(Quirk::Urg);
     }
     if bits & quirk_bits::PUSH != 0 {
-        v.push(Quirk::Push);
+        set.insert(Quirk::Push);
     }
-    v
+    set
+}
+
+fn apply_option_quirks(quirks: &mut QuirkSet, valid_opts: &[u8], wscale: Option<u8>) {
+    if wscale.map(|ws| ws > 14).unwrap_or(false) {
+        quirks.insert(Quirk::ExcessiveWindowScaling);
+    }
+
+    let oq: OptionQuirks = scan_option_quirks(valid_opts);
+    if oq.ts_val == Some(0) {
+        quirks.insert(Quirk::OwnTimestampZero);
+    }
+    if oq.ts_ecr.map(|v| v != 0).unwrap_or(false) {
+        quirks.insert(Quirk::PeerTimestampNonZero);
+    }
+    if oq.trailing_nonzero {
+        quirks.insert(Quirk::TrailinigNonZero);
+    }
+}
+
+/// DSCP from the IP ToS / traffic-class byte (bits 2–7).
+fn dscp_from_tos(ip_tos: u8) -> u8 {
+    ip_tos.wrapping_shr(2)
 }
 
 pub fn parse_syn_v6(raw: &SynRawDataV6) -> Option<TcpObservation> {
     let window_host = u16::from_be(raw.window);
-    let valid_opts = &raw.options[..usize::from(raw.optlen.min(40))];
+    let optlen = raw.optlen.min(40);
+    let valid_opts = &raw.options[..usize::from(optlen)];
 
     let parsed: ParsedTcpOptions = parse_options_raw(valid_opts);
     if parsed.malformed {
@@ -104,49 +126,34 @@ pub fn parse_syn_v6(raw: &SynRawDataV6) -> Option<TcpObservation> {
     }
 
     let ittl: Ttl = ttl::calculate_ttl(raw.ip_ttl);
-    // IPv6 fixed header is 40 bytes; no IP options.
-    let ip_plus_tcp: u16 = 60;
-    let wsize: WindowSize = window_size::detect_win_multiplicator(
-        window_host,
-        parsed.mss.unwrap_or(0),
-        ip_plus_tcp,
-        parsed.olayout.contains(&TcpOption::TS),
-        &IpVersion::V6,
-    );
+    // IPv6 fixed header (40) + TCP header including options (20 + optlen).
+    let tot_hdr = 40_u16
+        .saturating_add(20)
+        .saturating_add(u16::from(optlen));
 
-    let mut quirks: Vec<Quirk> = decode_quirks(raw.quirks);
-
-    if parsed.wscale.map(|ws| ws > 14).unwrap_or(false) {
-        quirks.push(Quirk::ExcessiveWindowScaling);
-    }
-
-    let oq: OptionQuirks = scan_option_quirks(valid_opts);
-    if oq.ts_val == Some(0) {
-        quirks.push(Quirk::OwnTimestampZero);
-    }
-    if oq.ts_ecr.map(|v| v != 0).unwrap_or(false) {
-        quirks.push(Quirk::PeerTimestampNonZero);
-    }
-    if oq.trailing_nonzero {
-        quirks.push(Quirk::TrailinigNonZero);
-    }
+    let mut quirks = decode_quirks(raw.quirks);
+    apply_option_quirks(&mut quirks, valid_opts, parsed.wscale);
 
     Some(TcpObservation {
         version: IpVersion::V6,
         ittl,
         olen: 0,
         mss: parsed.mss,
-        wsize,
+        wsize: window_host,
+        tot_hdr,
         wscale: parsed.wscale,
         olayout: parsed.olayout,
         quirks,
         pclass: PayloadSize::Zero,
+        peer_mss: None,
+        tos: dscp_from_tos(raw.ip_tos),
     })
 }
 
 pub fn parse_syn_v4(raw: &SynRawDataV4) -> Option<TcpObservation> {
     let window_host = u16::from_be(raw.window);
-    let valid_opts = &raw.options[..usize::from(raw.optlen.min(40))];
+    let optlen = raw.optlen.min(40);
+    let valid_opts = &raw.options[..usize::from(optlen)];
 
     let parsed: ParsedTcpOptions = parse_options_raw(valid_opts);
     if parsed.malformed {
@@ -159,43 +166,27 @@ pub fn parse_syn_v4(raw: &SynRawDataV4) -> Option<TcpObservation> {
     }
 
     let ittl: Ttl = ttl::calculate_ttl(raw.ip_ttl);
-    let ip_plus_tcp = 20_u16
+    // IP header (20 + ip_olen) + TCP header including options (20 + optlen).
+    let tot_hdr = 20_u16
         .saturating_add(u16::from(raw.ip_olen))
-        .saturating_add(20);
-    let wsize: WindowSize = window_size::detect_win_multiplicator(
-        window_host,
-        parsed.mss.unwrap_or(0),
-        ip_plus_tcp,
-        parsed.olayout.contains(&TcpOption::TS),
-        &IpVersion::V4,
-    );
+        .saturating_add(20)
+        .saturating_add(u16::from(optlen));
 
-    let mut quirks: Vec<Quirk> = decode_quirks(raw.quirks);
-
-    if parsed.wscale.map(|ws| ws > 14).unwrap_or(false) {
-        quirks.push(Quirk::ExcessiveWindowScaling);
-    }
-
-    let oq: OptionQuirks = scan_option_quirks(valid_opts);
-    if oq.ts_val == Some(0) {
-        quirks.push(Quirk::OwnTimestampZero);
-    }
-    if oq.ts_ecr.map(|v| v != 0).unwrap_or(false) {
-        quirks.push(Quirk::PeerTimestampNonZero);
-    }
-    if oq.trailing_nonzero {
-        quirks.push(Quirk::TrailinigNonZero);
-    }
+    let mut quirks = decode_quirks(raw.quirks);
+    apply_option_quirks(&mut quirks, valid_opts, parsed.wscale);
 
     Some(TcpObservation {
         version: IpVersion::V4,
         ittl,
         olen: raw.ip_olen,
         mss: parsed.mss,
-        wsize,
+        wsize: window_host,
+        tot_hdr,
         wscale: parsed.wscale,
         olayout: parsed.olayout,
         quirks,
         pclass: PayloadSize::Zero,
+        peer_mss: None,
+        tos: dscp_from_tos(raw.ip_tos),
     })
 }

--- a/huginn-ebpf/tests/parse_syn.rs
+++ b/huginn-ebpf/tests/parse_syn.rs
@@ -1,5 +1,5 @@
 use huginn_ebpf::types::{parse_syn_v4, parse_syn_v6, quirk_bits, SynRawDataV4, SynRawDataV6};
-use huginn_net_tcp::tcp::{IpVersion, Quirk};
+use huginn_net_tcp::tcp::{IpVersion, PayloadSize, Quirk};
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -259,6 +259,40 @@ fn test_parse_syn_v6_fields() -> TestResult {
     let sig = obs.to_string();
     assert!(sig.starts_with("6:"), "signature must start with IPv6 version: {sig}");
     assert!(sig.contains("flow"), "Display must include p0f flow quirk: {sig}");
+    Ok(())
+}
+
+/// PAYLOAD_NONZERO rides in the quirks bitmask but must decode to pclass, not a quirk.
+#[test]
+fn test_payload_nonzero_bit_sets_pclass() -> TestResult {
+    let (options, optlen) = make_test_options();
+
+    let bare = make_syn_raw_with_quirks(65535u16.to_be(), 64, optlen, options, 0);
+    let sig = parse_syn_v4(&bare)
+        .ok_or("parse_syn_v4 returned None")?
+        .to_string();
+    assert!(sig.ends_with(":0"), "SYN without data must have pclass 0: {sig}");
+
+    let with_data = make_syn_raw_with_quirks(
+        65535u16.to_be(),
+        64,
+        optlen,
+        options,
+        quirk_bits::PAYLOAD_NONZERO,
+    );
+    let obs = parse_syn_v4(&with_data).ok_or("parse_syn_v4 returned None")?;
+    assert_eq!(obs.pclass, PayloadSize::NonZero, "TFO SYN must have pclass +");
+    let sig = obs.to_string();
+    assert!(sig.ends_with(":+"), "TFO SYN must render pclass +: {sig}");
+
+    let v6 = make_syn_raw_v6(65535u16.to_be(), 64, 0, optlen, options, quirk_bits::PAYLOAD_NONZERO);
+    let obs = parse_syn_v6(&v6).ok_or("parse_syn_v6 returned None")?;
+    assert_eq!(obs.pclass, PayloadSize::NonZero);
+    assert!(
+        obs.quirks.is_empty(),
+        "PAYLOAD_NONZERO must not decode as a quirk, got: {:?}",
+        obs.quirks
+    );
     Ok(())
 }
 

--- a/huginn-ebpf/tests/parse_syn.rs
+++ b/huginn-ebpf/tests/parse_syn.rs
@@ -32,14 +32,26 @@ fn make_syn_raw_with_quirks(
     options: [u8; 40],
     quirks: u32,
 ) -> SynRawDataV4 {
+    make_syn_raw_full(window, ip_ttl, 0, 0, optlen, options, quirks)
+}
+
+fn make_syn_raw_full(
+    window: u16,
+    ip_ttl: u8,
+    ip_tos: u8,
+    ip_olen: u8,
+    optlen: u8,
+    options: [u8; 40],
+    quirks: u32,
+) -> SynRawDataV4 {
     SynRawDataV4 {
         src_addr: 0,
         src_port: 0,
         window,
         optlen,
-        ip_tos: 0,
+        ip_tos,
         ip_ttl,
-        ip_olen: 0,
+        ip_olen,
         options,
         quirks,
         tick: 0,
@@ -146,12 +158,55 @@ fn test_all_quirk_bits_roundtrip() -> TestResult {
         let raw = make_syn_raw_with_quirks(65535u16.to_be(), 64, optlen, options, *bit);
         let obs = parse_syn_v4(&raw).ok_or("parse_syn_v4 returned None for valid options")?;
         assert!(
-            obs.quirks.contains(expected_quirk),
+            obs.quirks.contains(*expected_quirk),
             "quirk bit 0x{:x} should decode to {:?}, got quirks: {:?}",
             bit,
             expected_quirk,
             obs.quirks
         );
     }
+    Ok(())
+}
+
+#[test]
+fn test_raw_wsize_and_tot_hdr() -> TestResult {
+    let (options, optlen) = make_test_options();
+    let ip_olen = 0u8;
+    let raw = make_syn_raw_full(8192u16.to_be(), 64, 0, ip_olen, optlen, options, 0);
+    let obs = parse_syn_v4(&raw).ok_or("parse_syn_v4 returned None")?;
+
+    assert_eq!(obs.wsize, 8192, "wsize must be host-endian raw window");
+    assert_eq!(
+        obs.tot_hdr,
+        20u16
+            .saturating_add(u16::from(ip_olen))
+            .saturating_add(20)
+            .saturating_add(u16::from(optlen)),
+        "tot_hdr must include IP header + TCP header with options"
+    );
+    assert_eq!(obs.peer_mss, None, "SYN observations have no peer_mss");
+
+    let wsize_part = obs
+        .to_string()
+        .split(':')
+        .nth(4)
+        .ok_or("signature missing wsize field")?
+        .to_string();
+    // 8192 / 1460 is not exact; Display should keep the raw value or an mss*/mtu* form
+    // that does not look like a byte-swapped window.
+    assert!(
+        wsize_part.starts_with("8192,") || wsize_part.contains("mss*") || wsize_part.contains("mtu*"),
+        "unexpected wsize display field: {wsize_part}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_tos_is_dscp() -> TestResult {
+    let (options, optlen) = make_test_options();
+    // ToS 0xB8 → DSCP 0x2E (EF)
+    let raw = make_syn_raw_full(8192u16.to_be(), 64, 0xB8, 0, optlen, options, 0);
+    let obs = parse_syn_v4(&raw).ok_or("parse_syn_v4 returned None")?;
+    assert_eq!(obs.tos, 0x2E, "tos must be DSCP (ip_tos >> 2)");
     Ok(())
 }

--- a/huginn-ebpf/tests/parse_syn.rs
+++ b/huginn-ebpf/tests/parse_syn.rs
@@ -1,5 +1,5 @@
-use huginn_ebpf::types::{parse_syn_v4, quirk_bits, SynRawDataV4};
-use huginn_net_tcp::tcp::Quirk;
+use huginn_ebpf::types::{parse_syn_v4, parse_syn_v6, quirk_bits, SynRawDataV4, SynRawDataV6};
+use huginn_net_tcp::tcp::{IpVersion, Quirk};
 
 type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -52,6 +52,28 @@ fn make_syn_raw_full(
         ip_tos,
         ip_ttl,
         ip_olen,
+        options,
+        quirks,
+        tick: 0,
+    }
+}
+
+fn make_syn_raw_v6(
+    window: u16,
+    ip_ttl: u8,
+    ip_tos: u8,
+    optlen: u8,
+    options: [u8; 40],
+    quirks: u32,
+) -> SynRawDataV6 {
+    SynRawDataV6 {
+        src_addr: [0u8; 16],
+        src_port: 0,
+        window,
+        optlen,
+        ip_tos,
+        ip_ttl,
+        _pad: 0,
         options,
         quirks,
         tick: 0,
@@ -153,6 +175,7 @@ fn test_all_quirk_bits_roundtrip() -> TestResult {
         (quirk_bits::NONZERO_URG, Quirk::NonZeroURG),
         (quirk_bits::URG, Quirk::Urg),
         (quirk_bits::PUSH, Quirk::Push),
+        (quirk_bits::FLOW, Quirk::FlowID),
     ];
     for (bit, expected_quirk) in cases {
         let raw = make_syn_raw_with_quirks(65535u16.to_be(), 64, optlen, options, *bit);
@@ -195,7 +218,9 @@ fn test_raw_wsize_and_tot_hdr() -> TestResult {
     // 8192 / 1460 is not exact; Display should keep the raw value or an mss*/mtu* form
     // that does not look like a byte-swapped window.
     assert!(
-        wsize_part.starts_with("8192,") || wsize_part.contains("mss*") || wsize_part.contains("mtu*"),
+        wsize_part.starts_with("8192,")
+            || wsize_part.contains("mss*")
+            || wsize_part.contains("mtu*"),
         "unexpected wsize display field: {wsize_part}"
     );
     Ok(())
@@ -209,4 +234,40 @@ fn test_tos_is_dscp() -> TestResult {
     let obs = parse_syn_v4(&raw).ok_or("parse_syn_v4 returned None")?;
     assert_eq!(obs.tos, 0x2E, "tos must be DSCP (ip_tos >> 2)");
     Ok(())
+}
+
+#[test]
+fn test_parse_syn_v6_fields() -> TestResult {
+    let (options, optlen) = make_test_options();
+    // traffic class 0xB8 → DSCP 0x2E
+    let raw = make_syn_raw_v6(8192u16.to_be(), 64, 0xB8, optlen, options, quirk_bits::FLOW);
+    let obs = parse_syn_v6(&raw).ok_or("parse_syn_v6 returned None")?;
+
+    assert_eq!(obs.version, IpVersion::V6);
+    assert_eq!(obs.olen, 0, "IPv6 fixed-header path has no extension olen");
+    assert_eq!(
+        obs.tot_hdr,
+        40u16.saturating_add(20).saturating_add(u16::from(optlen)),
+        "tot_hdr must be IPv6 header + TCP header with options"
+    );
+    assert_eq!(obs.wsize, 8192);
+    assert_eq!(obs.tos, 0x2E);
+    assert_eq!(obs.peer_mss, None);
+    assert!(obs.quirks.contains(Quirk::FlowID));
+    assert!(!obs.quirks.contains(Quirk::Df), "IPv4-only quirks must not appear");
+
+    let sig = obs.to_string();
+    assert!(sig.starts_with("6:"), "signature must start with IPv6 version: {sig}");
+    assert!(sig.contains("flow"), "Display must include p0f flow quirk: {sig}");
+    Ok(())
+}
+
+#[test]
+fn test_parse_syn_v6_empty_options() {
+    let raw = make_syn_raw_v6(8192u16.to_be(), 128, 0, 0, [0u8; 40], 0);
+    let Some(obs) = parse_syn_v6(&raw) else {
+        panic!("parse_syn_v6 returned None for empty options");
+    };
+    assert_eq!(obs.tot_hdr, 60);
+    assert_eq!(obs.olen, 0);
 }

--- a/huginn-proxy-lib/src/fingerprinting/headers.rs
+++ b/huginn-proxy-lib/src/fingerprinting/headers.rs
@@ -53,8 +53,8 @@ pub mod names {
     /// Header name for TCP SYN p0f-style raw signature injection
     ///
     /// This header contains the raw TCP SYN fingerprint extracted via eBPF/XDP.
-    /// Format: `"ver:ittl:olen:mss:wsize,wscale:olayout"`
-    /// Example: `"4:64:0:1460:8192,6:mss,nop,ws,nop,nop,ts,sok"`
+    /// Format: `"ver:ittl:olen:mss:wsize,wscale:olayout:quirks:pclass"` (8 colon-separated fields)
+    /// Example: `"4:64:0:1460:mss*4,6:mss,nop,ws,nop,nop,ts,sok::0"`
     /// Only injected when the `ebpf-tcp` feature is enabled and fingerprinting is configured.
     pub const TCP_SYN: &str = "x-tcp-p0f";
 


### PR DESCRIPTION
## Summary
Migrate TCP SYN fingerprinting to huginn-net-tcp 2.1.0 and align the p0f signature (ver:ittl:olen:mss:wsize,wscale:olayout:quirks:pclass) with huginn-net’s live pipeline for both IPv4 and IPv6.

The eBPF capture path and userspace parser now produce the same observation that visit_tcp / tcp_observation would, so the injected x-tcp-p0f header matches the reference library.

huginn-net 2.1 API

- Bump huginn-net-tcp / huginn-net-http / huginn-net-tls to 2.1.0.
- Rebuild TcpObservation for the new shape: QuirkSet instead of Vec<Quirk>, raw u16 window (wsize), tot_hdr, DSCP tos, and peer_mss: None on SYN.
- Window MSS/MTU scaling is left to huginn-net’s Display implementation (detect_win_multi), not recomputed in the proxy.
- tot_hdr is IP header (20 + ip_olen, or 40 for IPv6) plus TCP header including options (20 + optlen).
- tos is DSCP (ip_tos >> 2 / traffic class bits 2–7).

**Intentional deviation**
Malformed TCP options: huginn-net still emits a partial olayout. We drop the fingerprint so we do not inject a eader that cannot match the database.