### PR TITLE
Graceful shutdown refactor

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -177,7 +177,7 @@ mounts the same ConfigMap; a parse, unknown-field, or cross-reference error prev
 ### Proxy (observability server)
 
 - `/health` - general health check (alias of liveness, always 200 while running)
-- `/ready` - readiness probe: 200 once listeners are accepting connections; 503 while starting up and during graceful shutdown (fails first on SIGTERM so traffic drains cleanly).
+- `/ready` - readiness probe: 200 once listeners are accepting connections; 503 while starting up (`proxy_starting`) and during graceful shutdown (`proxy_draining`). With `timeout.drain_delay_secs > 0`, `/ready` fails first while the process still accepts traffic so the load balancer can drain; then the listen socket closes.
 - `/live` - liveness probe (200 while the process is alive)
 - `/metrics` - Prometheus metrics
 
@@ -251,7 +251,7 @@ continues running with the old values.
 | `[fingerprint]` | Fingerprinting feature flags (`tcp_enabled`, `tls_enabled`, `http_enabled`, `max_capture`) — static because they control eBPF program loading and capture buffers at startup |
 | `[logging]` | Log level and format |
 | `[telemetry]` | Metrics port and OpenTelemetry log level |
-| `[timeout]` | `upstream_connect_ms` (TCP connect to backend; absent = no timeout), `proxy_idle_ms` (inbound idle), `tls_handshake_secs`, `connection_handling_secs`, `shutdown_secs`, `keep_alive.upstream_idle_timeout` |
+| `[timeout]` | `upstream_connect_ms` (TCP connect to backend; absent = no timeout), `proxy_idle_ms` (inbound idle), `tls_handshake_secs`, `connection_handling_secs`, `drain_delay_secs`, `shutdown_secs`, `keep_alive.upstream_idle_timeout` |
 | `[security].max_connections` | Maximum concurrent connections |
 
 > **TLS certificates** are re-read as part of a **config reload**, not by an

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -177,9 +177,11 @@ mounts the same ConfigMap; a parse, unknown-field, or cross-reference error prev
 ### Proxy (observability server)
 
 - `/health` - general health check (alias of liveness, always 200 while running)
-- `/ready` - readiness probe: 200 once listeners are accepting connections; 503 while starting up (`proxy_starting`) and during graceful shutdown (`proxy_draining`). With `timeout.drain_delay_secs > 0`, `/ready` fails first while the process still accepts traffic so the load balancer can drain; then the listen socket closes.
-- `/live` - liveness probe (200 while the process is alive)
+- `/ready` - Kubernetes `readinessProbe` and load-balancer health: 200 once listeners are accepting connections; 503 while starting up (`proxy_starting`) and during graceful shutdown (`proxy_draining`). With `timeout.drain_delay_secs > 0`, `/ready` fails first while the process still accepts traffic so the load balancer can drain; then the listen socket closes.
+- `/live` - Kubernetes `livenessProbe` (200 while the process is alive; stays 200 during drain so kubelet does not SIGKILL the pod)
 - `/metrics` - Prometheus metrics
+
+Size `drain_delay_secs + shutdown_secs` below `terminationGracePeriodSeconds` (or systemd `TimeoutStopSec`).
 
 ### eBPF agent (observability server)
 

--- a/EBPF-SETUP.md
+++ b/EBPF-SETUP.md
@@ -51,9 +51,26 @@ accounting (still supported but deprecated). Check: `uname -r`.
 
 ### One agent per node
 
-Linux allows only one XDP or TC clsact program attached to a network interface at a time.
-If two agents run on the same node, the second replaces the first's program. Deploy the
-agent as a DaemonSet (K8s) or with `network_mode: "service:proxy"` (Docker Compose).
+Deploy the agent as a DaemonSet (K8s) or with `network_mode: "service:proxy"` (Docker Compose).
+What happens if two agents do land on the same node depends on the backend, and none of the
+outcomes are good:
+
+| Backend                        | Second agent                                                                                                                                                     |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `xdp-native`, `xdp-skb`        | Attach fails with `EBUSY`. Only one XDP program per interface without a libxdp dispatcher.                                                                       |
+| `tc` on kernel ≥ 6.6 (TCX)     | **Both stay attached.** The TCX multi-prog API stacks programs on the hook instead of replacing, so both capture and the `syn_captured_*` counters double-count. |
+| `tc` on kernel < 6.6 (netlink) | Both stay attached as separate clsact filters with different priorities. Same double-counting.                                                                   |
+
+The `tc` cases are the dangerous ones: nothing errors and nothing logs, so a duplicated agent
+looks healthy while inflating counters.
+
+### Kernel ≥ 6.6 for TCX (backend `tc` only)
+
+With `HUGINN_EBPF_CAPTURE=tc`, aya picks the attach mechanism at load time based on the running
+kernel — TCX (`bpf_link`, multi-prog API) on ≥ 6.6, legacy netlink clsact filter below. The
+selection is silent: same config, same logs, different mechanism. Both capture SYNs identically,
+so this only matters if you depend on TCX properties (`bpf_link` pinning, explicit ordering,
+`bpf_mprog` queries). Check with `uname -r`.
 
 ### bpffs
 
@@ -77,21 +94,21 @@ do not SNAT.
 
 The agent requires the following Linux capabilities and security settings:
 
-| Capability / Setting | Purpose |
-|---|---|
-| `CAP_BPF` | Create BPF maps and load BPF programs |
-| `CAP_NET_ADMIN` | Attach XDP program to a network interface |
-| `CAP_PERFMON` | Allow pointer arithmetic in BPF verifier |
-| `seccomp: unconfined` | Docker's default seccomp blocks the `bpf()` syscall |
+| Capability / Setting   | Purpose                                                          |
+|------------------------|------------------------------------------------------------------|
+| `CAP_BPF`              | Create BPF maps and load BPF programs                            |
+| `CAP_NET_ADMIN`        | Attach XDP program to a network interface                        |
+| `CAP_PERFMON`          | Allow pointer arithmetic in BPF verifier                         |
+| `seccomp: unconfined`  | Docker's default seccomp blocks the `bpf()` syscall              |
 | `apparmor: unconfined` | Ubuntu/Debian's AppArmor profile blocks bpffs directory creation |
 
 ## Proxy capabilities
 
 The proxy only reads pinned BPF maps:
 
-| Capability | Purpose |
-|---|---|
-| `CAP_BPF` | Open pinned BPF maps via `BPF_OBJ_GET` |
+| Capability | Purpose                                |
+|------------|----------------------------------------|
+| `CAP_BPF`  | Open pinned BPF maps via `BPF_OBJ_GET` |
 
 No `seccomp:unconfined` or `apparmor:unconfined` needed.
 
@@ -101,19 +118,19 @@ No `seccomp:unconfined` or `apparmor:unconfined` needed.
 
 ### Agent environment variables
 
-| Variable | Example | Description |
-|---|---|---|
-| `HUGINN_EBPF_INTERFACE` | `eth0` | Network interface for the capture program (XDP or TC) |
-| `HUGINN_EBPF_DST_IP_V4` | `0.0.0.0` | IPv4 destination filter (`0.0.0.0` = no filter) |
-| `HUGINN_EBPF_DST_IP_V6` | `::` | IPv6 destination filter (`::` = no filter); quote in YAML if needed |
-| `HUGINN_EBPF_DST_PORT` | `7000` | Destination port filter (proxy listen port) |
-| `HUGINN_EBPF_PIN_PATH` | `/sys/fs/bpf/huginn` | Pin directory (default shown) |
-| `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES` | `8192` | LRU map capacity (default shown). Agent-only: the agent publishes this value into the family-agnostic `syn_meta` map, and the proxy reads it from there for its staleness threshold — so it must not be set on the proxy. |
-| `HUGINN_EBPF_CAPTURE` | `xdp-native` | Capture backend: `xdp-native` (driver XDP, default), `xdp-skb` (generic XDP, veth/loopback/VMs), or `tc` (clsact ingress; GRO-safe when native XDP is unavailable, e.g. VLAN/bond on generic XDP). Same BPF maps either way. |
-| `HUGINN_EBPF_LOG_LEVEL` | `off` | Verbosity of in-kernel `aya-log` datapath logging: `off` (default), `error`, `warn`, `info`, `debug`, `trace`. The kernel emits only records at/above the level (`debug` = per-capture, `warn` = map-insert failures), so the level gate runs in-kernel and `off` is zero-cost on the hot path. When non-`off` and `RUST_LOG` is unset, the agent defaults its filter to that level so records are shown. For diagnostics only. |
-| `HUGINN_EBPF_RATE_LIMIT_ENABLED` | `false` | Enable the in-kernel per-source-IP SYN rate limiter. When on, SYNs from an IP exceeding the threshold are skipped (not captured/fingerprinted); the packet still passes to the stack (never dropped). Uses a dual-buffer sliding-window Count-Min Sketch, hashed with a random seed drawn per agent load so the counter layout is not predictable from outside. |
-| `HUGINN_EBPF_RATE_LIMIT_BURST` | `2000` | Max SYNs per window per source IP before its SYNs stop being captured. Range `1..=65534`. Counted **per CPU**, and *not* the proxy's `[security.rate_limit] burst`: size it with [Sizing the SYN rate limiter](#sizing-the-syn-rate-limiter). |
-| `HUGINN_EBPF_RATE_LIMIT_WINDOW_SECONDS` | `1` | Sliding-window length in seconds. Range `1..=3600`. Once a source crosses `burst`, its SYNs are skipped until the window ends, so a long window means a long gap in that source's fingerprints. |
+| Variable                                | Example              | Description                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|-----------------------------------------|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HUGINN_EBPF_INTERFACE`                 | `eth0`               | Network interface for the capture program (XDP or TC)                                                                                                                                                                                                                                                                                                                                                                           |
+| `HUGINN_EBPF_DST_IP_V4`                 | `0.0.0.0`            | IPv4 destination filter (`0.0.0.0` = no filter)                                                                                                                                                                                                                                                                                                                                                                                 |
+| `HUGINN_EBPF_DST_IP_V6`                 | `::`                 | IPv6 destination filter (`::` = no filter); quote in YAML if needed                                                                                                                                                                                                                                                                                                                                                             |
+| `HUGINN_EBPF_DST_PORT`                  | `7000`               | Destination port filter (proxy listen port)                                                                                                                                                                                                                                                                                                                                                                                     |
+| `HUGINN_EBPF_PIN_PATH`                  | `/sys/fs/bpf/huginn` | Pin directory (default shown)                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `HUGINN_EBPF_SYN_MAP_MAX_ENTRIES`       | `8192`               | LRU map capacity (default shown). Agent-only: the agent publishes this value into the family-agnostic `syn_meta` map, and the proxy reads it from there for its staleness threshold — so it must not be set on the proxy.                                                                                                                                                                                                       |
+| `HUGINN_EBPF_CAPTURE`                   | `xdp-native`         | Capture backend: `xdp-native` (driver XDP, default), `xdp-skb` (generic XDP, veth/loopback/VMs), or `tc` (clsact ingress; GRO-safe when native XDP is unavailable, e.g. VLAN/bond on generic XDP). Same BPF maps either way. There is no `tcx` value: `tc` attaches via TCX automatically on kernel ≥ 6.6, see [Kernel ≥ 6.6 for TCX](#kernel--66-for-tcx-backend-tc-only).                                                     |
+| `HUGINN_EBPF_LOG_LEVEL`                 | `off`                | Verbosity of in-kernel `aya-log` datapath logging: `off` (default), `error`, `warn`, `info`, `debug`, `trace`. The kernel emits only records at/above the level (`debug` = per-capture, `warn` = map-insert failures), so the level gate runs in-kernel and `off` is zero-cost on the hot path. When non-`off` and `RUST_LOG` is unset, the agent defaults its filter to that level so records are shown. For diagnostics only. |
+| `HUGINN_EBPF_RATE_LIMIT_ENABLED`        | `false`              | Enable the in-kernel per-source-IP SYN rate limiter. When on, SYNs from an IP exceeding the threshold are skipped (not captured/fingerprinted); the packet still passes to the stack (never dropped). Uses a dual-buffer sliding-window Count-Min Sketch, hashed with a random seed drawn per agent load so the counter layout is not predictable from outside.                                                                 |
+| `HUGINN_EBPF_RATE_LIMIT_BURST`          | `2000`               | Max SYNs per window per source IP before its SYNs stop being captured. Range `1..=65534`. Counted **per CPU**, and *not* the proxy's `[security.rate_limit] burst`: size it with [Sizing the SYN rate limiter](#sizing-the-syn-rate-limiter).                                                                                                                                                                                   |
+| `HUGINN_EBPF_RATE_LIMIT_WINDOW_SECONDS` | `1`                  | Sliding-window length in seconds. Range `1..=3600`. Once a source crosses `burst`, its SYNs are skipped until the window ends, so a long window means a long gap in that source's fingerprints.                                                                                                                                                                                                                                 |
 
 > **Bad rate-limit value stops the agent**, like every other agent variable. An unset variable
 > takes its default; one that is set but unusable exits with a message. Note the proxy waits on
@@ -159,12 +176,12 @@ burst = HUGINN_EBPF_SYN_MAP_MAX_ENTRIES / (4 × cpus)
 so one source's real ceiling is `burst × cpus`. That product is what you are sizing: as cores grow,
 `burst` shrinks and the ceiling stays put.
 
-| LRU | `cpus` | `burst` | Ceiling per source IP |
-|---|---|---|---|
-| 8192 (default) | 1 (veth in a VM) | `2048` | 2048, a quarter of the map |
-| 8192 | 4 queues | `512` | 2048, a quarter of the map |
-| 8192 | 32 queues | `64` | 2048, a quarter of the map |
-| 32768 | 8 queues | `1024` | 8192, a quarter of the map |
+| LRU            | `cpus`           | `burst` | Ceiling per source IP      |
+|----------------|------------------|---------|----------------------------|
+| 8192 (default) | 1 (veth in a VM) | `2048`  | 2048, a quarter of the map |
+| 8192           | 4 queues         | `512`   | 2048, a quarter of the map |
+| 8192           | 32 queues        | `64`    | 2048, a quarter of the map |
+| 32768          | 8 queues         | `1024`  | 8192, a quarter of the map |
 
 The `4 ×` is a conservative default, not a measured one: it caps one source at a quarter of the map
 and leaves the rest for everyone else. Err on the low side. Going over only skips fingerprint
@@ -186,7 +203,8 @@ mechanism differ.
 - **`xdp-skb`** — generic XDP in the kernel stack. Works on veth/loopback/VMs.
 - **`tc`** — TC `clsact` **ingress** classifier. Reads packet bytes via `bpf_skb_load_bytes`
   (GRO-safe) and returns `TC_ACT_OK`, so it **never drops** packets and works on **VLAN/bond**
-  interfaces.
+  interfaces. Attaches via TCX on kernel ≥ 6.6 and via a legacy netlink filter below — see
+  [Kernel ≥ 6.6 for TCX](#kernel--66-for-tcx-backend-tc-only).
 
 > Use `tc` when native XDP is not available and you would otherwise fall back to generic XDP
 > (`xdp-skb`). Generic XDP does not handle GRO-aggregated (multi-buffer) packets: the program
@@ -201,10 +219,10 @@ mechanism differ.
 tcp_enabled = true   # false = no BPF maps opened, no capabilities needed
 ```
 
-| Variable | Example | Description |
-|---|---|---|
-| `HUGINN_EBPF_PIN_PATH` | `/sys/fs/bpf/huginn` | Pin directory to read maps from (default shown) |
-| `HUGINN_EBPF_RECONNECT_POLL_SECS` | `5` | Backstop poll interval for detecting recreated maps (e.g. a capacity change or a wiped bpffs); `0` disables automatic reconnection. Normal agent restarts reuse the same maps and need no reconnection |
+| Variable                          | Example              | Description                                                                                                                                                                                            |
+|-----------------------------------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `HUGINN_EBPF_PIN_PATH`            | `/sys/fs/bpf/huginn` | Pin directory to read maps from (default shown)                                                                                                                                                        |
+| `HUGINN_EBPF_RECONNECT_POLL_SECS` | `5`                  | Backstop poll interval for detecting recreated maps (e.g. a capacity change or a wiped bpffs); `0` disables automatic reconnection. Normal agent restarts reuse the same maps and need no reconnection |
 
 At startup the proxy retries opening the pinned maps with a fixed backoff until the agent has
 pinned them, so the two containers can start in any order. See
@@ -225,13 +243,13 @@ a bpffs Docker volume for map pinning.
 services:
   ebpf-agent:
     network_mode: "service:proxy"
-    cap_add: [CAP_BPF, CAP_NET_ADMIN, CAP_PERFMON]
-    security_opt: [seccomp:unconfined, apparmor:unconfined]
+    cap_add: [ CAP_BPF, CAP_NET_ADMIN, CAP_PERFMON ]
+    security_opt: [ seccomp:unconfined, apparmor:unconfined ]
     volumes:
       - bpffs:/sys/fs/bpf
 
   proxy:
-    cap_add: [CAP_BPF]
+    cap_add: [ CAP_BPF ]
     volumes:
       - bpffs:/sys/fs/bpf
 
@@ -255,7 +273,7 @@ host's bpffs via `hostPath`.
 # Agent DaemonSet (abbreviated)
 securityContext:
   capabilities:
-    add: [BPF, NET_ADMIN, PERFMON]
+    add: [ BPF, NET_ADMIN, PERFMON ]
   seccompProfile:
     type: Unconfined
 volumeMounts:
@@ -270,7 +288,7 @@ volumes:
 # Proxy Deployment (abbreviated)
 securityContext:
   capabilities:
-    add: [BPF]
+    add: [ BPF ]
   seccompProfile:
     type: RuntimeDefault
 volumeMounts:
@@ -347,6 +365,7 @@ accept time and reused for every request on that connection. As a result, **`x-t
 present on all requests** of a keep-alive connection, not just the first.
 
 A `SynResult::Miss` (no header injected) happens when:
+
 - the SYN was not captured (proxy just started, map entry evicted), or
 - the entry is stale (more than `2 x syn_map_max_entries` SYNs arrived since capture). The proxy
   reads `syn_map_max_entries` from the family-agnostic `syn_meta` map the agent publishes, so the

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -332,7 +332,8 @@ Multiple timeout controls to prevent resource exhaustion:
 - `tls_handshake_secs` (default: 15s) — Maximum time for completing TLS handshake.
 - `connection_handling_secs` (default: 300s) — Maximum total time for entire connection lifecycle (read + process +
   write).
-- `shutdown_secs` (default: 30s) — Graceful shutdown window.
+- `drain_delay_secs` (default: 0s) — Fail `/ready` while still accepting. `0` = 503 and stop accept together.
+- `shutdown_secs` (default: 30s) — After drain delay, window for in-flight connections to finish.
 - `keep_alive.upstream_idle_timeout` (default: 60s) — TCP keep-alive interval for proxy → backend connections.
 
 All timeouts are independently configurable.

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1105,7 +1105,8 @@ values.
 | `proxy_idle_ms`            | integer | `60000`             | Inbound idle timeout in milliseconds. Applied as HTTP/1.1 `header_read_timeout` and HTTP/2 keep-alive interval.                       |
 | `tls_handshake_secs`       | integer | `15`                | Maximum seconds to complete the client TLS handshake. Slow/malicious clients that stall the handshake are disconnected.               |
 | `connection_handling_secs` | integer | `300`               | Maximum total seconds for a full connection lifecycle (read request + proxy + write response). Guards against extremely slow clients. |
-| `shutdown_secs`            | integer | `30`                | Graceful shutdown window. In-flight requests have this many seconds to complete before the process exits.                             |
+| `drain_delay_secs`         | integer | `0`                 | Seconds to fail `/ready` while still accepting connections (graceful drain phase 1). `0` = fail readiness and stop accepting together. |
+| `shutdown_secs`            | integer | `30`                | After drain delay: seconds for in-flight requests to finish after the listen socket closes (phase 2).                                 |
 
 <table>
 <thead>
@@ -1124,6 +1125,7 @@ upstream_connect_ms = 5000
 proxy_idle_ms = 60000
 tls_handshake_secs = 15
 connection_handling_secs = 300
+drain_delay_secs = 0
 shutdown_secs = 30
 ```
 
@@ -1136,6 +1138,7 @@ timeout:
   proxy_idle_ms: 60000
   tls_handshake_secs: 15
   connection_handling_secs: 300
+  drain_delay_secs: 0
   shutdown_secs: 30
 ```
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -1105,7 +1105,7 @@ values.
 | `proxy_idle_ms`            | integer | `60000`             | Inbound idle timeout in milliseconds. Applied as HTTP/1.1 `header_read_timeout` and HTTP/2 keep-alive interval.                       |
 | `tls_handshake_secs`       | integer | `15`                | Maximum seconds to complete the client TLS handshake. Slow/malicious clients that stall the handshake are disconnected.               |
 | `connection_handling_secs` | integer | `300`               | Maximum total seconds for a full connection lifecycle (read request + proxy + write response). Guards against extremely slow clients. |
-| `drain_delay_secs`         | integer | `0`                 | Seconds to fail `/ready` while still accepting connections (graceful drain phase 1). `0` = fail readiness and stop accepting together. |
+| `drain_delay_secs`         | integer | `0`                 | Seconds to fail `/ready` while still accepting connections (graceful drain phase 1). `0` = fail readiness and stop accepting together. Size so `drain_delay_secs + shutdown_secs` is less than the orchestrator stop grace (`terminationGracePeriodSeconds`, systemd `TimeoutStopSec`). |
 | `shutdown_secs`            | integer | `30`                | After drain delay: seconds for in-flight requests to finish after the listen socket closes (phase 2).                                 |
 
 <table>

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -12,7 +12,9 @@ Huginn Proxy provides comprehensive telemetry through:
 - **Prometheus Metrics** - 52 metrics covering connections, PROXY protocol, requests, TLS, fingerprinting, backends, active health
   checks, throughput, rate limiting, IP filtering, header manipulation, mTLS, config hot reload, TLS certificate
   hot reload, and fingerprint spoofing detection
-- **Health Check Endpoints** - Kubernetes-ready: `/health`, `/ready`, `/live`, `/metrics`
+- **Health Check Endpoints** - Kubernetes-ready: `/health`, `/ready`, `/live`, `/metrics`. `/ready` is 503 with
+  `reason` `proxy_starting` until listeners bind, and `proxy_draining` during graceful shutdown phase 1 (while
+  traffic is still accepted). `/live` and `/health` stay 200 while the process is up.
 - **Structured Logs** - one secret-safe effective-config summary at startup (`info`), with the
   complete redacted effective config available at `debug`
 

--- a/benches/bench_proxy.rs
+++ b/benches/bench_proxy.rs
@@ -160,6 +160,7 @@ impl BenchFixture {
             timeout: TimeoutConfig {
                 upstream_connect_ms: Some(5000),
                 proxy_idle_ms: 600_000, // 10 min - bench groups share a connection pool
+                drain_delay_secs: 0,
                 shutdown_secs: 5,
                 tls_handshake_secs: 10,
                 connection_handling_secs: 600, // 10 min - each group runs ~15s warmup + 15s measure

--- a/examples/config/compose.toml
+++ b/examples/config/compose.toml
@@ -181,6 +181,7 @@ pool_max_idle_per_host = 0
 [timeout]
 upstream_connect_ms = 5000
 proxy_idle_ms = 60000
+drain_delay_secs = 1
 shutdown_secs = 30
 tls_handshake_secs = 15
 connection_handling_secs = 300

--- a/examples/config/compose.yaml
+++ b/examples/config/compose.yaml
@@ -171,6 +171,7 @@ backend_pool:
 timeout:
   upstream_connect_ms: 5000
   proxy_idle_ms: 60000
+  drain_delay_secs: 1
   shutdown_secs: 30
   tls_handshake_secs: 15
   connection_handling_secs: 300

--- a/huginn-proxy-lib/src/config/startup/timeout.rs
+++ b/huginn-proxy-lib/src/config/startup/timeout.rs
@@ -13,6 +13,11 @@ pub struct TimeoutConfig {
     /// Default: 60000 (60 seconds)
     #[serde(default = "default_proxy_idle_ms")]
     pub proxy_idle_ms: u64,
+    /// Seconds to fail `/ready` while still accepting (phase 1). `0` = fail
+    /// readiness and stop accepting together (historical behaviour).
+    /// Default: 0
+    #[serde(default)]
+    pub drain_delay_secs: u64,
     /// Graceful shutdown timeout in seconds
     /// Default: 30
     #[serde(default = "default_shutdown_timeout")]
@@ -44,6 +49,7 @@ impl Default for TimeoutConfig {
         Self {
             upstream_connect_ms: None,
             proxy_idle_ms: default_proxy_idle_ms(),
+            drain_delay_secs: 0,
             shutdown_secs: default_shutdown_timeout(),
             tls_handshake_secs: default_tls_handshake_timeout(),
             connection_handling_secs: default_connection_handling_timeout(),
@@ -116,6 +122,7 @@ fn default_upstream_idle_timeout() -> u64 {
 pub(crate) struct TimeoutView {
     upstream_connect_ms: Option<u64>,
     proxy_idle_ms: u64,
+    drain_delay_secs: u64,
     shutdown_secs: u64,
     tls_handshake_secs: u64,
     connection_handling_secs: u64,
@@ -133,6 +140,7 @@ impl TimeoutConfig {
         TimeoutView {
             upstream_connect_ms: self.upstream_connect_ms,
             proxy_idle_ms: self.proxy_idle_ms,
+            drain_delay_secs: self.drain_delay_secs,
             shutdown_secs: self.shutdown_secs,
             tls_handshake_secs: self.tls_handshake_secs,
             connection_handling_secs: self.connection_handling_secs,

--- a/huginn-proxy-lib/src/config/watcher.rs
+++ b/huginn-proxy-lib/src/config/watcher.rs
@@ -78,7 +78,7 @@ pub fn spawn_config_watcher(
         loop {
             tokio::select! {
                 biased;
-                _ = shutdown_rx.wait_for(|v| *v) => {
+                _ = shutdown_rx.wait_for(|phase| phase.is_stopping()) => {
                     info!("Config watcher task shutting down");
                     break;
                 }

--- a/huginn-proxy-lib/src/lib.rs
+++ b/huginn-proxy-lib/src/lib.rs
@@ -26,4 +26,4 @@ pub use proxy::reload::{
 pub use proxy::server::{SynProbe, WatchOptions};
 pub use proxy::shutdown::{shutdown_channel, ShutdownPhase, ShutdownSender, ShutdownWatch};
 pub use proxy::{forwarding, run};
-pub use telemetry::{Metrics, Readiness};
+pub use telemetry::{Metrics, NotReadyReason, Readiness};

--- a/huginn-proxy-lib/src/lib.rs
+++ b/huginn-proxy-lib/src/lib.rs
@@ -24,6 +24,6 @@ pub use proxy::reload::{
     initial_client_pool, initial_rate_limiter, try_reload, SharedClientPool, SharedRateLimiter,
 };
 pub use proxy::server::{SynProbe, WatchOptions};
-pub use proxy::shutdown::{shutdown_channel, ShutdownSender, ShutdownWatch};
+pub use proxy::shutdown::{shutdown_channel, ShutdownPhase, ShutdownSender, ShutdownWatch};
 pub use proxy::{forwarding, run};
 pub use telemetry::{Metrics, Readiness};

--- a/huginn-proxy-lib/src/proxy/accept.rs
+++ b/huginn-proxy-lib/src/proxy/accept.rs
@@ -15,7 +15,6 @@ use crate::tls::setup::SharedServerCrypto;
 use hyper_util::rt::TokioExecutor;
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::time::{Duration, Instant};
@@ -48,17 +47,16 @@ pub struct AcceptContext {
 pub async fn accept_loop(
     addr: SocketAddr,
     listener: TcpListener,
-    shutdown_signal: Arc<AtomicUsize>,
     mut shutdown_rx: ShutdownWatch,
     connection_manager: Arc<ConnectionManager>,
     ctx: Arc<AcceptContext>,
 ) {
     loop {
-        if shutdown_signal.load(Ordering::Relaxed) != 0 {
+        if shutdown_rx.borrow().is_stopping() {
             break;
         }
 
-        // Exit promptly on shutdown even when no new connections arrive.
+        // Exit promptly on Stopping even when no new connections arrive.
         let (stream, socket_peer) = tokio::select! {
             accepted = listener.accept() => match accepted {
                 Ok(pair) => pair,
@@ -67,7 +65,7 @@ pub async fn accept_loop(
                     continue;
                 }
             },
-            _ = shutdown_rx.changed() => break,
+            _ = shutdown_rx.wait_for(|phase| phase.is_stopping()) => break,
         };
 
         // Count against the socket peer, before spawning, so a full table never spawns doomed tasks.
@@ -84,6 +82,7 @@ pub async fn accept_loop(
         };
 
         let ctx_task = Arc::clone(&ctx);
+        let shutdown_rx = shutdown_rx.clone();
         tokio::spawn(async move {
             let _guard = guard;
             let mut stream = stream;
@@ -160,6 +159,7 @@ pub async fn accept_loop(
                         client_pool: ctx_task.client_pool.load_full(),
                         syn_fingerprint: syn_fingerprint.clone(),
                         upstream: upstream.clone(),
+                        shutdown_rx: shutdown_rx.clone(),
                     },
                 )
                 .await;
@@ -179,6 +179,7 @@ pub async fn accept_loop(
                         client_pool: ctx_task.client_pool.load_full(),
                         syn_fingerprint,
                         upstream,
+                        shutdown_rx,
                     },
                 )
                 .await;

--- a/huginn-proxy-lib/src/proxy/connection/manager.rs
+++ b/huginn-proxy-lib/src/proxy/connection/manager.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 use tokio::sync::watch;
 use tracing::warn;
 
+use crate::proxy::shutdown::{ShutdownPhase, ShutdownSender};
 use crate::telemetry::metrics::values;
 use crate::telemetry::Metrics;
 
@@ -22,20 +23,20 @@ pub enum ConnectionError {
 pub struct ConnectionManager {
     active_connections: Arc<AtomicUsize>,
     max_connections: usize,
-    shutdown_signal: Arc<AtomicUsize>,
+    shutdown_tx: ShutdownSender,
     connections_closed_tx: watch::Sender<()>,
 }
 
 impl ConnectionManager {
     pub fn new(
         max_connections: usize,
-        shutdown_signal: Arc<AtomicUsize>,
+        shutdown_tx: ShutdownSender,
         connections_closed_tx: watch::Sender<()>,
     ) -> Self {
         Self {
             active_connections: Arc::new(AtomicUsize::new(0)),
             max_connections,
-            shutdown_signal,
+            shutdown_tx,
             connections_closed_tx,
         }
     }
@@ -45,9 +46,9 @@ impl ConnectionManager {
         self.active_connections.clone()
     }
 
-    /// Check if shutdown was requested
+    /// Check if shutdown has entered [`ShutdownPhase::Stopping`].
     pub fn is_shutdown(&self) -> bool {
-        self.shutdown_signal.load(Ordering::Relaxed) == 1
+        *self.shutdown_tx.borrow() == ShutdownPhase::Stopping
     }
 
     /// Try to accept a new connection
@@ -57,7 +58,6 @@ impl ConnectionManager {
         peer: std::net::SocketAddr,
         metrics: &Arc<Metrics>,
     ) -> Result<ConnectionGuard, ConnectionError> {
-        // Check if shutdown was requested
         if self.is_shutdown() {
             return Err(ConnectionError::Shutdown);
         }

--- a/huginn-proxy-lib/src/proxy/server.rs
+++ b/huginn-proxy-lib/src/proxy/server.rs
@@ -12,7 +12,9 @@ use crate::proxy::protocol::warn_proxy_protocol_trust_gap;
 use crate::proxy::reload::{
     initial_client_pool, initial_rate_limiter, try_reload, SharedDynamicConfig,
 };
-use crate::proxy::shutdown::{wait_for_drain, ServiceHandle, ShutdownPhase, ShutdownSender};
+use crate::proxy::shutdown::{
+    begin_shutdown, wait_for_drain, ServiceHandle, ShutdownPhase, ShutdownSender,
+};
 pub use crate::proxy::watch::WatchOptions;
 use crate::telemetry::{Metrics, Readiness};
 use crate::tls::setup::SharedServerCrypto;
@@ -281,34 +283,4 @@ pub async fn run(
 
     info!("Proxy server stopped");
     Ok(())
-}
-
-async fn begin_shutdown(
-    signal: &str,
-    readiness: &Readiness,
-    shutdown_tx: &ShutdownSender,
-    sigterm: &mut signal::unix::Signal,
-    sigint: &mut signal::unix::Signal,
-    drain_delay: Duration,
-) {
-    info!(signal, "Initiating graceful shutdown");
-    readiness.mark_draining();
-    let _ = shutdown_tx.send(ShutdownPhase::Draining);
-
-    if drain_delay.is_zero() {
-        return;
-    }
-
-    info!(secs = drain_delay.as_secs(), "Failing readiness, still accepting");
-    tokio::select! {
-        _ = tokio::time::sleep(drain_delay) => {
-            info!("Drain delay elapsed");
-        }
-        _ = sigterm.recv() => {
-            info!("Second SIGTERM, skipping remaining drain delay");
-        }
-        _ = sigint.recv() => {
-            info!("Second SIGINT, skipping remaining drain delay");
-        }
-    }
 }

--- a/huginn-proxy-lib/src/proxy/server.rs
+++ b/huginn-proxy-lib/src/proxy/server.rs
@@ -12,7 +12,7 @@ use crate::proxy::protocol::warn_proxy_protocol_trust_gap;
 use crate::proxy::reload::{
     initial_client_pool, initial_rate_limiter, try_reload, SharedDynamicConfig,
 };
-use crate::proxy::shutdown::{wait_for_drain, ServiceHandle, ShutdownSender};
+use crate::proxy::shutdown::{wait_for_drain, ServiceHandle, ShutdownPhase, ShutdownSender};
 pub use crate::proxy::watch::WatchOptions;
 use crate::telemetry::{Metrics, Readiness};
 use crate::tls::setup::SharedServerCrypto;
@@ -21,7 +21,6 @@ use arc_swap::ArcSwap;
 use hyper_util::rt::{TokioExecutor, TokioTimer};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
 use std::net::SocketAddr;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::runtime::Handle;
@@ -91,11 +90,10 @@ pub async fn run(
         None
     };
 
-    let shutdown_signal = Arc::new(AtomicUsize::new(0));
     let (connections_closed_tx, connections_closed_rx) = watch::channel(());
     let connection_manager = Arc::new(ConnectionManager::new(
         static_cfg.max_connections,
-        shutdown_signal.clone(),
+        shutdown_tx.clone(),
         connections_closed_tx.clone(),
     ));
 
@@ -169,7 +167,6 @@ pub async fn run(
         accept_tasks.spawn(accept_loop(
             addr,
             listener,
-            Arc::clone(&shutdown_signal),
             shutdown_rx.clone(),
             Arc::clone(&connection_manager),
             Arc::clone(&ctx),
@@ -233,24 +230,34 @@ pub async fn run(
                 }
             }
             _ = sigterm.recv() => {
-                info!("Received SIGTERM, initiating graceful shutdown");
-                readiness.mark_not_ready();
-                health_supervisor.shutdown();
-                shutdown_signal.store(1, Ordering::Relaxed);
-                shutdown_tx.send(true).ok();
+                begin_shutdown(
+                    "SIGTERM",
+                    &readiness,
+                    &shutdown_tx,
+                    &mut sigterm,
+                    &mut sigint,
+                    Duration::from_secs(static_cfg.timeout.drain_delay_secs),
+                )
+                .await;
                 break;
             }
             _ = sigint.recv() => {
-                info!("Received SIGINT, initiating graceful shutdown");
-                readiness.mark_not_ready();
-                health_supervisor.shutdown();
-                shutdown_signal.store(1, Ordering::Relaxed);
-                shutdown_tx.send(true).ok();
+                begin_shutdown(
+                    "SIGINT",
+                    &readiness,
+                    &shutdown_tx,
+                    &mut sigterm,
+                    &mut sigint,
+                    Duration::from_secs(static_cfg.timeout.drain_delay_secs),
+                )
+                .await;
                 break;
             }
         }
     }
 
+    health_supervisor.shutdown();
+    let _ = shutdown_tx.send(ShutdownPhase::Stopping);
     accept_tasks.abort_all();
     drop(accept_tasks);
 
@@ -274,4 +281,34 @@ pub async fn run(
 
     info!("Proxy server stopped");
     Ok(())
+}
+
+async fn begin_shutdown(
+    signal: &str,
+    readiness: &Readiness,
+    shutdown_tx: &ShutdownSender,
+    sigterm: &mut signal::unix::Signal,
+    sigint: &mut signal::unix::Signal,
+    drain_delay: Duration,
+) {
+    info!(signal, "Initiating graceful shutdown");
+    readiness.mark_draining();
+    let _ = shutdown_tx.send(ShutdownPhase::Draining);
+
+    if drain_delay.is_zero() {
+        return;
+    }
+
+    info!(secs = drain_delay.as_secs(), "Failing readiness, still accepting");
+    tokio::select! {
+        _ = tokio::time::sleep(drain_delay) => {
+            info!("Drain delay elapsed");
+        }
+        _ = sigterm.recv() => {
+            info!("Second SIGTERM, skipping remaining drain delay");
+        }
+        _ = sigint.recv() => {
+            info!("Second SIGINT, skipping remaining drain delay");
+        }
+    }
 }

--- a/huginn-proxy-lib/src/proxy/shutdown.rs
+++ b/huginn-proxy-lib/src/proxy/shutdown.rs
@@ -27,6 +27,8 @@ use std::fmt;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use crate::telemetry::Readiness;
+use tokio::signal;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant};
@@ -111,6 +113,38 @@ impl ServiceHandle {
                 self.name,
                 timeout.as_secs()
             ),
+        }
+    }
+}
+
+/// Fail `/ready` and enter [`ShutdownPhase::Draining`]. Accept loops keep running
+/// until `drain_delay` elapses or a second SIGTERM/SIGINT arrives.
+pub async fn begin_shutdown(
+    signal: &str,
+    readiness: &Readiness,
+    shutdown_tx: &ShutdownSender,
+    sigterm: &mut signal::unix::Signal,
+    sigint: &mut signal::unix::Signal,
+    drain_delay: Duration,
+) {
+    info!(signal, "Initiating graceful shutdown");
+    readiness.mark_draining();
+    let _ = shutdown_tx.send(ShutdownPhase::Draining);
+
+    if drain_delay.is_zero() {
+        return;
+    }
+
+    info!(secs = drain_delay.as_secs(), "Failing readiness, still accepting");
+    tokio::select! {
+        _ = tokio::time::sleep(drain_delay) => {
+            info!("Drain delay elapsed");
+        }
+        _ = sigterm.recv() => {
+            info!("Second SIGTERM, skipping remaining drain delay");
+        }
+        _ = sigint.recv() => {
+            info!("Second SIGINT, skipping remaining drain delay");
         }
     }
 }

--- a/huginn-proxy-lib/src/proxy/shutdown.rs
+++ b/huginn-proxy-lib/src/proxy/shutdown.rs
@@ -5,24 +5,22 @@
 //! ```text
 //! SIGTERM / SIGINT
 //!   │
-//!   └─▶ shutdown_tx.send(true)          (server.rs)
-//!         │
-//!         ├─▶ config-watcher task       (config/watcher.rs)
-//!         │     shutdown_rx.wait_for(true) → break
-//!         │
-//!         ├─▶ metrics-server task       (main.rs)
-//!         │     shutdown_rx.wait_for(true) → break
-//!         │
-//!         ├─▶ ebpf-reconnect task       (ebpf.rs)
-//!         │     shutdown_rx.wait_for(true) → break
-//!         │
-//!         └─▶ wait_for_drain            (server.rs)
-//!               waits for all active HTTP connections to finish,
-//!               then ServiceHandle::shutdown() awaits each background task
+//!   ├─▶ phase = Draining                (server.rs)  /ready = 503
+//!   │     accept loops keep running
+//!   │     sleep drain_delay_secs (second signal skips)
+//!   │
+//!   ├─▶ phase = Stopping
+//!   │     │
+//!   │     ├─▶ accept loops              wait_for(Stopping) → break
+//!   │     ├─▶ config-watcher            wait_for(Stopping) → break
+//!   │     ├─▶ ebpf-reconnect            wait_for(Stopping) → break
+//!   │     └─▶ connections               graceful_shutdown() then wait_for_drain
+//!   │
+//!   └─▶ observability server            stopped by main.rs after run() returns
 //! ```
 //!
-//! Every background task receives a [`ShutdownWatch`] clone and selects on it
-//! against its main work loop. [`ServiceHandle`] wraps the resulting
+//! Every background task receives a [`ShutdownWatch`] clone and selects on
+//! [`ShutdownPhase::Stopping`]. [`ServiceHandle`] wraps the resulting
 //! `JoinHandle` and is awaited in order during drain.
 
 use std::fmt;
@@ -34,22 +32,37 @@ use tokio::task::JoinHandle;
 use tokio::time::{Duration, Instant};
 use tracing::{info, warn};
 
+/// Two-phase process lifetime. `Draining` fails readiness but keeps accepting;
+/// `Stopping` closes the listen socket and GOAWAYs existing connections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShutdownPhase {
+    Running,
+    Draining,
+    Stopping,
+}
+
+impl ShutdownPhase {
+    /// Tasks that must keep working through drain wait for this.
+    pub fn is_stopping(self) -> bool {
+        matches!(self, Self::Stopping)
+    }
+}
+
 /// Canonical shutdown signal type, adapted from Pingora's `ShutdownWatch`.
 ///
-/// Each background task receives a clone and selects on `wait_for(|v| *v)`
-/// against its main work. When `true` is sent, tasks exit their loops
-/// cooperatively and flush any pending log lines before returning.
-pub type ShutdownWatch = watch::Receiver<bool>;
+/// Each background task receives a clone and selects on
+/// `wait_for(|phase| phase.is_stopping())`.
+pub type ShutdownWatch = watch::Receiver<ShutdownPhase>;
 
 /// The sending half of the shutdown channel.
 ///
-/// Owned at the top level (`main.rs`). Calling `send(true)` broadcasts to
-/// every task that holds a `ShutdownWatch` clone.
-pub type ShutdownSender = watch::Sender<bool>;
+/// Owned at the top level (`main.rs`). Broadcasts [`ShutdownPhase`] to every
+/// task that holds a [`ShutdownWatch`] clone.
+pub type ShutdownSender = watch::Sender<ShutdownPhase>;
 
-/// Create the shutdown channel initialised to `false` (not shutting down).
+/// Create the shutdown channel initialised to [`ShutdownPhase::Running`].
 pub fn shutdown_channel() -> (ShutdownSender, ShutdownWatch) {
-    watch::channel(false)
+    watch::channel(ShutdownPhase::Running)
 }
 
 /// Identifies each background service for logging during shutdown.
@@ -102,11 +115,17 @@ impl ServiceHandle {
     }
 }
 
+/// Wait until `active_connections` is 0 or `timeout_secs` elapses.
+///
+/// Clears a stale `changed()` notification first so closures that happened
+/// before phase 2 cannot release the drain early.
 pub async fn wait_for_drain(
     mut connections_closed_rx: watch::Receiver<()>,
     active_connections: Arc<AtomicUsize>,
     timeout_secs: u64,
 ) {
+    connections_closed_rx.borrow_and_update();
+
     if active_connections.load(Ordering::Relaxed) == 0 {
         info!("All connections closed, shutdown complete");
         return;
@@ -115,23 +134,36 @@ pub async fn wait_for_drain(
     let start = Instant::now();
     let deadline = crate::utils::deadline_from(start, Duration::from_secs(timeout_secs));
 
-    let timed_out = tokio::select! {
-        _ = connections_closed_rx.changed() => false,
-        _ = tokio::time::sleep_until(deadline) => true,
-    };
+    loop {
+        let active = active_connections.load(Ordering::Relaxed);
+        if active == 0 {
+            info!("All connections closed, shutdown complete");
+            return;
+        }
+        if Instant::now() >= deadline {
+            warn!(
+                active_connections = active,
+                "Shutdown timeout reached, {active} connections still active"
+            );
+            return;
+        }
 
-    let active = active_connections.load(Ordering::Relaxed);
-    if active == 0 {
-        info!("All connections closed, shutdown complete");
-    } else if timed_out {
-        warn!(
-            active_connections = active,
-            "Shutdown timeout reached, {} connections still active", active
-        );
-    } else {
-        warn!(
-            active_connections = active,
-            "Connection closed notification received but {} connections still active", active
-        );
+        tokio::select! {
+            changed = connections_closed_rx.changed() => {
+                if changed.is_err() {
+                    let remaining = active_connections.load(Ordering::Relaxed);
+                    if remaining == 0 {
+                        info!("All connections closed, shutdown complete");
+                    } else {
+                        warn!(
+                            active_connections = remaining,
+                            "Connection-closed watch closed with {remaining} connections still active"
+                        );
+                    }
+                    return;
+                }
+            }
+            _ = tokio::time::sleep_until(deadline) => {}
+        }
     }
 }

--- a/huginn-proxy-lib/src/proxy/transport/plain.rs
+++ b/huginn-proxy-lib/src/proxy/transport/plain.rs
@@ -25,6 +25,7 @@ pub struct PlainConnectionConfig {
     pub client_pool: Arc<ClientPool>,
     pub syn_fingerprint: Option<TcpObservation>,
     pub upstream: UpstreamGateway,
+    pub shutdown_rx: crate::proxy::shutdown::ShutdownWatch,
 }
 
 /// Handle a plain HTTP connection
@@ -92,7 +93,19 @@ pub async fn handle_plain_connection(
         }
     });
 
-    let serve_fut = config.builder.serve_connection(TokioIo::new(stream), svc);
+    let serve_fut = Box::pin(
+        config
+            .builder
+            .serve_connection(TokioIo::new(stream), svc)
+            .into_owned(),
+    );
 
-    serve_with_timeout(serve_fut, config.connection_handling_timeout, config.metrics, peer).await;
+    serve_with_timeout(
+        serve_fut,
+        config.connection_handling_timeout,
+        config.shutdown_rx,
+        config.metrics,
+        peer,
+    )
+    .await;
 }

--- a/huginn-proxy-lib/src/proxy/transport/timeout_helper.rs
+++ b/huginn-proxy-lib/src/proxy/transport/timeout_helper.rs
@@ -1,25 +1,70 @@
+use crate::proxy::shutdown::ShutdownWatch;
 use crate::telemetry::metrics::values;
 use crate::telemetry::Metrics;
+use hyper::body::{Body, Incoming};
+use hyper::rt::{Read, Write};
+use hyper::service::HttpService;
+use hyper_util::rt::TokioExecutor;
+use hyper_util::server::conn::auto::{Connection, HttpServerConnExec};
+use std::fmt::Display;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use tracing::{debug, warn};
 
-pub async fn serve_with_timeout<F, E>(
-    serve_fut: F,
+/// HTTP connection future that can emit GOAWAY / `Connection: close`.
+pub trait GracefulShutdown {
+    fn graceful_shutdown(self: Pin<&mut Self>);
+}
+
+impl<I, S, B> GracefulShutdown for Connection<'static, I, S, TokioExecutor>
+where
+    S: HttpService<Incoming, ResBody = B>,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    I: Read + Write + Unpin + Send + 'static,
+    B: Body + 'static,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    TokioExecutor: HttpServerConnExec<S::Future, B>,
+{
+    fn graceful_shutdown(self: Pin<&mut Self>) {
+        Connection::graceful_shutdown(self);
+    }
+}
+
+pub async fn serve_with_timeout<C, Err>(
+    mut serve_fut: Pin<Box<C>>,
     timeout_duration: tokio::time::Duration,
+    mut shutdown_rx: ShutdownWatch,
     metrics: Arc<Metrics>,
     peer: std::net::SocketAddr,
 ) where
-    F: std::future::Future<Output = Result<(), E>>,
-    E: std::fmt::Display,
+    C: Future<Output = Result<(), Err>> + GracefulShutdown,
+    Err: Display,
 {
-    match pingora_timeout::timeout(timeout_duration, serve_fut).await {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => {
-            debug!(?peer, reason = %e, "connection ended");
-        }
-        Err(_) => {
-            warn!(?peer, "connection handling timeout");
-            metrics.record_timeout(values::TIMEOUT_CONNECTION_HANDLING);
+    let mut goaway_sent = false;
+    let start = tokio::time::Instant::now();
+    let deadline = crate::utils::deadline_from(start, timeout_duration);
+
+    loop {
+        tokio::select! {
+            result = serve_fut.as_mut() => {
+                match result {
+                    Ok(()) => {}
+                    Err(e) => {
+                        debug!(?peer, reason = %e, "connection ended");
+                    }
+                }
+                return;
+            }
+            _ = shutdown_rx.wait_for(|phase| phase.is_stopping()), if !goaway_sent => {
+                serve_fut.as_mut().graceful_shutdown();
+                goaway_sent = true;
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                warn!(?peer, "connection handling timeout");
+                metrics.record_timeout(values::TIMEOUT_CONNECTION_HANDLING);
+                return;
+            }
         }
     }
 }

--- a/huginn-proxy-lib/src/proxy/transport/timeout_helper.rs
+++ b/huginn-proxy-lib/src/proxy/transport/timeout_helper.rs
@@ -41,30 +41,32 @@ pub async fn serve_with_timeout<C, Err>(
     C: Future<Output = Result<(), Err>> + GracefulShutdown,
     Err: Display,
 {
-    let mut goaway_sent = false;
-    let start = tokio::time::Instant::now();
-    let deadline = crate::utils::deadline_from(start, timeout_duration);
-
-    loop {
-        tokio::select! {
-            result = serve_fut.as_mut() => {
-                match result {
-                    Ok(()) => {}
-                    Err(e) => {
-                        debug!(?peer, reason = %e, "connection ended");
+    let serve = async {
+        let mut goaway_sent = false;
+        loop {
+            tokio::select! {
+                result = serve_fut.as_mut() => {
+                    match result {
+                        Ok(()) => {}
+                        Err(e) => {
+                            debug!(?peer, reason = %e, "connection ended");
+                        }
                     }
+                    return;
                 }
-                return;
-            }
-            _ = shutdown_rx.wait_for(|phase| phase.is_stopping()), if !goaway_sent => {
-                serve_fut.as_mut().graceful_shutdown();
-                goaway_sent = true;
-            }
-            _ = tokio::time::sleep_until(deadline) => {
-                warn!(?peer, "connection handling timeout");
-                metrics.record_timeout(values::TIMEOUT_CONNECTION_HANDLING);
-                return;
+                _ = shutdown_rx.wait_for(|phase| phase.is_stopping()), if !goaway_sent => {
+                    serve_fut.as_mut().graceful_shutdown();
+                    goaway_sent = true;
+                }
             }
         }
+    };
+
+    if pingora_timeout::timeout(timeout_duration, serve)
+        .await
+        .is_err()
+    {
+        warn!(?peer, "connection handling timeout");
+        metrics.record_timeout(values::TIMEOUT_CONNECTION_HANDLING);
     }
 }

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -36,6 +36,7 @@ pub struct TlsConnectionConfig {
     pub client_pool: Arc<ClientPool>,
     pub syn_fingerprint: Option<TcpObservation>,
     pub upstream: UpstreamGateway,
+    pub shutdown_rx: crate::proxy::shutdown::ShutdownWatch,
 }
 
 /// Handle a TLS connection
@@ -208,12 +209,21 @@ pub async fn handle_tls_connection(
                     }
                 });
 
-            let serve_fut = config
-                .builder
-                .serve_connection(TokioIo::new(capturing_stream), svc);
+            let serve_fut = Box::pin(
+                config
+                    .builder
+                    .serve_connection(TokioIo::new(capturing_stream), svc)
+                    .into_owned(),
+            );
 
-            serve_with_timeout(serve_fut, config.connection_handling_timeout, config.metrics, peer)
-                .await;
+            serve_with_timeout(
+                serve_fut,
+                config.connection_handling_timeout,
+                config.shutdown_rx.clone(),
+                config.metrics,
+                peer,
+            )
+            .await;
         } else {
             let backends = config.backends.clone();
             let domains = config.domains.clone();
@@ -275,10 +285,21 @@ pub async fn handle_tls_connection(
                     }
                 });
 
-            let serve_fut = config.builder.serve_connection(TokioIo::new(tls), svc);
+            let serve_fut = Box::pin(
+                config
+                    .builder
+                    .serve_connection(TokioIo::new(tls), svc)
+                    .into_owned(),
+            );
 
-            serve_with_timeout(serve_fut, config.connection_handling_timeout, config.metrics, peer)
-                .await;
+            serve_with_timeout(
+                serve_fut,
+                config.connection_handling_timeout,
+                config.shutdown_rx,
+                config.metrics,
+                peer,
+            )
+            .await;
         }
     }
 }

--- a/huginn-proxy-lib/src/telemetry/health.rs
+++ b/huginn-proxy-lib/src/telemetry/health.rs
@@ -2,6 +2,7 @@ use hyper::Response;
 use hyper::StatusCode;
 use tracing::warn;
 
+use crate::telemetry::readiness::NotReadyReason;
 use crate::telemetry::status::{Status, StatusBody};
 use crate::utils::http::{json_response, RespBody};
 
@@ -19,14 +20,14 @@ pub fn live_check_response() -> Response<RespBody> {
 /// accepting connections.
 /// `not_ready_reason` is `None` when ready; otherwise the JSON `reason`
 /// (`proxy_starting` or `proxy_draining`).
-pub fn ready_check_response(not_ready_reason: Option<&'static str>) -> Response<RespBody> {
+pub fn ready_check_response(not_ready_reason: Option<NotReadyReason>) -> Response<RespBody> {
     let Some(reason) = not_ready_reason else {
         return json_response(StatusCode::OK, StatusBody::new(Status::Ready));
     };
 
-    warn!(reason, "Readiness check failed");
+    warn!(reason = reason.as_str(), "Readiness check failed");
     json_response(
         StatusCode::SERVICE_UNAVAILABLE,
-        StatusBody::with_reason(Status::NotReady, reason),
+        StatusBody::with_reason(Status::NotReady, reason.as_str()),
     )
 }

--- a/huginn-proxy-lib/src/telemetry/health.rs
+++ b/huginn-proxy-lib/src/telemetry/health.rs
@@ -17,15 +17,14 @@ pub fn live_check_response() -> Response<RespBody> {
 
 /// Readiness check - reports whether the proxy has finished starting up and is
 /// accepting connections.
-/// `ready` is `false` while the listeners are still binding/initialising and during
-/// graceful shutdown; `true` once the proxy is accepting connections.
-pub fn ready_check_response(ready: bool) -> Response<RespBody> {
-    if ready {
+/// `not_ready_reason` is `None` when ready; otherwise the JSON `reason`
+/// (`proxy_starting` or `proxy_draining`).
+pub fn ready_check_response(not_ready_reason: Option<&'static str>) -> Response<RespBody> {
+    let Some(reason) = not_ready_reason else {
         return json_response(StatusCode::OK, StatusBody::new(Status::Ready));
-    }
+    };
 
-    let reason = "proxy_starting";
-    warn!(reason, "Readiness check failed: proxy is not accepting connections yet");
+    warn!(reason, "Readiness check failed");
     json_response(
         StatusCode::SERVICE_UNAVAILABLE,
         StatusBody::with_reason(Status::NotReady, reason),

--- a/huginn-proxy-lib/src/telemetry/mod.rs
+++ b/huginn-proxy-lib/src/telemetry/mod.rs
@@ -10,6 +10,6 @@ pub mod tracing;
 pub use health::{health_check_response, live_check_response, ready_check_response};
 pub use metrics::{init_metrics, values, Metrics};
 pub use metrics_handler::handle_metrics;
-pub use readiness::Readiness;
+pub use readiness::{NotReadyReason, Readiness};
 pub use server::start_observability_server;
 pub use tracing::{init_tracing_with_otel, init_validation_tracing, shutdown_tracing};

--- a/huginn-proxy-lib/src/telemetry/readiness.rs
+++ b/huginn-proxy-lib/src/telemetry/readiness.rs
@@ -43,9 +43,10 @@ impl Readiness {
         self.0.ready.store(false, Ordering::Release);
     }
 
-    /// Whether the proxy is currently ready to accept traffic.
+    /// Whether `/ready` would return 200. Same source of truth as the HTTP probe
+    /// (`not_ready_reason`).
     pub fn is_ready(&self) -> bool {
-        self.0.ready.load(Ordering::Acquire)
+        self.not_ready_reason().is_none()
     }
 
     /// `None` when ready; otherwise the `/ready` JSON `reason`.

--- a/huginn-proxy-lib/src/telemetry/readiness.rs
+++ b/huginn-proxy-lib/src/telemetry/readiness.rs
@@ -3,27 +3,60 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-#[derive(Clone, Default)]
-pub struct Readiness(Arc<AtomicBool>);
+struct Inner {
+    ready: AtomicBool,
+    draining: AtomicBool,
+}
+
+#[derive(Clone)]
+pub struct Readiness(Arc<Inner>);
+
+impl Default for Readiness {
+    fn default() -> Self {
+        Self(Arc::new(Inner {
+            ready: AtomicBool::new(false),
+            draining: AtomicBool::new(false),
+        }))
+    }
+}
 
 impl Readiness {
-    /// Create a new handle in the not-ready state.
+    /// Create a new handle in the not-ready state (`proxy_starting`).
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Mark the proxy as ready to accept traffic (`/ready` -> 200).
     pub fn mark_ready(&self) {
-        self.0.store(true, Ordering::Release);
+        self.0.draining.store(false, Ordering::Release);
+        self.0.ready.store(true, Ordering::Release);
     }
 
     /// Mark the proxy as not ready (`/ready` -> 503), e.g. during graceful shutdown.
     pub fn mark_not_ready(&self) {
-        self.0.store(false, Ordering::Release);
+        self.0.ready.store(false, Ordering::Release);
+    }
+
+    /// Fail `/ready` with `proxy_draining` while listeners still accept.
+    pub fn mark_draining(&self) {
+        self.0.draining.store(true, Ordering::Release);
+        self.0.ready.store(false, Ordering::Release);
     }
 
     /// Whether the proxy is currently ready to accept traffic.
     pub fn is_ready(&self) -> bool {
-        self.0.load(Ordering::Acquire)
+        self.0.ready.load(Ordering::Acquire)
+    }
+
+    /// `None` when ready; otherwise the `/ready` JSON `reason`.
+    pub fn not_ready_reason(&self) -> Option<&'static str> {
+        if self.0.ready.load(Ordering::Acquire) {
+            return None;
+        }
+        if self.0.draining.load(Ordering::Acquire) {
+            Some("proxy_draining")
+        } else {
+            Some("proxy_starting")
+        }
     }
 }

--- a/huginn-proxy-lib/src/telemetry/readiness.rs
+++ b/huginn-proxy-lib/src/telemetry/readiness.rs
@@ -24,6 +24,40 @@ struct Inner {
     draining: AtomicBool,
 }
 
+/// Shared state behind the observability server's `/ready` endpoint.
+///
+/// Cheap to clone (`Arc` inside). `run()` holds one handle and the observability server
+/// another; both observe the same state.
+///
+/// # Lifecycle
+///
+/// ```text
+/// new()           503 proxy_starting
+/// mark_ready()    200                   listeners bound (server.rs)
+/// mark_draining() 503 proxy_draining    SIGTERM; listeners keep accepting
+/// ```
+///
+/// Draining is terminal: `mark_ready()` cannot undo it. Readiness only fails the probe so
+/// the load balancer stops sending new traffic; closing the listen socket is
+/// [`ShutdownPhase::Stopping`](crate::proxy::shutdown::ShutdownPhase::Stopping)'s job, one
+/// `timeout.drain_delay_secs` later. Letting readiness flip back to 200 inside that window
+/// would hand traffic to a process about to stop accepting.
+///
+/// ```
+/// use huginn_proxy_lib::{NotReadyReason, Readiness};
+///
+/// let readiness = Readiness::new();
+/// assert_eq!(readiness.not_ready_reason(), Some(NotReadyReason::ProxyStarting));
+///
+/// readiness.mark_ready();
+/// assert!(readiness.is_ready());
+///
+/// readiness.mark_draining();
+/// assert_eq!(readiness.not_ready_reason(), Some(NotReadyReason::ProxyDraining));
+///
+/// readiness.mark_ready();
+/// assert_eq!(readiness.not_ready_reason(), Some(NotReadyReason::ProxyDraining));
+/// ```
 #[derive(Clone)]
 pub struct Readiness(Arc<Inner>);
 
@@ -43,17 +77,15 @@ impl Readiness {
     }
 
     /// Mark the proxy as ready to accept traffic (`/ready` -> 200).
+    ///
+    /// Does not clear `draining`: once shutdown starts there is no way back to 200.
     pub fn mark_ready(&self) {
-        self.0.draining.store(false, Ordering::Release);
         self.0.ready.store(true, Ordering::Release);
     }
 
-    /// Mark the proxy as not ready (`/ready` -> 503), e.g. during graceful shutdown.
-    pub fn mark_not_ready(&self) {
-        self.0.ready.store(false, Ordering::Release);
-    }
-
     /// Fail `/ready` with `proxy_draining` while listeners still accept.
+    ///
+    /// Terminal: no other method leaves this state.
     pub fn mark_draining(&self) {
         self.0.draining.store(true, Ordering::Release);
         self.0.ready.store(false, Ordering::Release);
@@ -66,12 +98,14 @@ impl Readiness {
     }
 
     /// `None` when ready; otherwise why `/ready` is 503.
+    ///
+    /// Draining is checked first so it outranks every other reason.
     pub fn not_ready_reason(&self) -> Option<NotReadyReason> {
-        if self.0.ready.load(Ordering::Acquire) {
-            return None;
-        }
         if self.0.draining.load(Ordering::Acquire) {
-            Some(NotReadyReason::ProxyDraining)
+            return Some(NotReadyReason::ProxyDraining);
+        }
+        if self.0.ready.load(Ordering::Acquire) {
+            None
         } else {
             Some(NotReadyReason::ProxyStarting)
         }

--- a/huginn-proxy-lib/src/telemetry/readiness.rs
+++ b/huginn-proxy-lib/src/telemetry/readiness.rs
@@ -3,6 +3,22 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+/// Why `/ready` is 503. Serialized as the JSON `reason` snake_case string at the HTTP edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotReadyReason {
+    ProxyStarting,
+    ProxyDraining,
+}
+
+impl NotReadyReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ProxyStarting => "proxy_starting",
+            Self::ProxyDraining => "proxy_draining",
+        }
+    }
+}
+
 struct Inner {
     ready: AtomicBool,
     draining: AtomicBool,
@@ -49,15 +65,15 @@ impl Readiness {
         self.not_ready_reason().is_none()
     }
 
-    /// `None` when ready; otherwise the `/ready` JSON `reason`.
-    pub fn not_ready_reason(&self) -> Option<&'static str> {
+    /// `None` when ready; otherwise why `/ready` is 503.
+    pub fn not_ready_reason(&self) -> Option<NotReadyReason> {
         if self.0.ready.load(Ordering::Acquire) {
             return None;
         }
         if self.0.draining.load(Ordering::Acquire) {
-            Some("proxy_draining")
+            Some(NotReadyReason::ProxyDraining)
         } else {
-            Some("proxy_starting")
+            Some(NotReadyReason::ProxyStarting)
         }
     }
 }

--- a/huginn-proxy-lib/src/telemetry/router.rs
+++ b/huginn-proxy-lib/src/telemetry/router.rs
@@ -11,7 +11,7 @@ use crate::utils::http::{json_response, RespBody};
 pub fn dispatch(path: &str, registry: &Registry, readiness: &Readiness) -> Response<RespBody> {
     let response = match path {
         "/health" => health_check_response(),
-        "/ready" => ready_check_response(readiness.is_ready()),
+        "/ready" => ready_check_response(readiness.not_ready_reason()),
         "/live" => live_check_response(),
         "/metrics" => handle_metrics(registry).unwrap_or_else(|e| {
             warn!(error = %e, "Failed to encode metrics");

--- a/huginn-proxy-lib/src/telemetry/server.rs
+++ b/huginn-proxy-lib/src/telemetry/server.rs
@@ -8,7 +8,7 @@ use prometheus::Registry;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::signal;
+use tokio::sync::watch;
 use tracing::{info, warn};
 
 /// Start the observability server that handles metrics and health checks
@@ -20,10 +20,14 @@ use tracing::{info, warn};
 ///
 /// `readiness` is flipped to `true` by the proxy once its listeners are accepting
 /// connections and back to `false` during graceful shutdown; `/ready` reflects it.
+///
+/// Shutdown is **not** tied to SIGTERM: the process signal is used for traffic
+/// drain. `main` sends `true` on `stop_rx` after `run()` returns.
 pub async fn start_observability_server(
     port: u16,
     registry: Registry,
     readiness: Readiness,
+    mut stop_rx: watch::Receiver<bool>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let registry = Arc::new(registry);
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -31,19 +35,10 @@ pub async fn start_observability_server(
 
     info!(?addr, "Observability server started (metrics + health checks)");
 
-    let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
-        .map_err(|e| std::io::Error::other(format!("Failed to setup SIGTERM handler: {e}")))?;
-    let mut sigint = signal::unix::signal(signal::unix::SignalKind::interrupt())
-        .map_err(|e| std::io::Error::other(format!("Failed to setup SIGINT handler: {e}")))?;
-
     loop {
         tokio::select! {
-            _ = sigterm.recv() => {
-                info!("Observability server: Received SIGTERM, shutting down");
-                break;
-            }
-            _ = sigint.recv() => {
-                info!("Observability server: Received SIGINT, shutting down");
+            _ = stop_rx.wait_for(|stop| *stop) => {
+                info!("Observability server: stop requested, shutting down");
                 break;
             }
             result = listener.accept() => {

--- a/huginn-proxy-lib/tests/capture_fixtures.rs
+++ b/huginn-proxy-lib/tests/capture_fixtures.rs
@@ -227,6 +227,7 @@ async fn capture_fingerprint_values() -> Result<(), Box<dyn std::error::Error + 
         timeout: TimeoutConfig {
             upstream_connect_ms: Some(5000),
             proxy_idle_ms: 30_000,
+            drain_delay_secs: 0,
             shutdown_secs: 3,
             tls_handshake_secs: 10,
             connection_handling_secs: 60,

--- a/huginn-proxy-lib/tests/config/types.rs
+++ b/huginn-proxy-lib/tests/config/types.rs
@@ -103,6 +103,7 @@ backends = [{ address = "backend:9000" }]
     let config: Config = toml::from_str(toml)?;
     assert_eq!(config.timeout.upstream_connect_ms, None);
     assert_eq!(config.timeout.proxy_idle_ms, 60000);
+    assert_eq!(config.timeout.drain_delay_secs, 0);
     assert_eq!(config.timeout.shutdown_secs, 30);
     assert_eq!(config.timeout.tls_handshake_secs, 15);
     assert_eq!(config.timeout.connection_handling_secs, 300);

--- a/huginn-proxy-lib/tests/hot_reload/pipeline.rs
+++ b/huginn-proxy-lib/tests/hot_reload/pipeline.rs
@@ -66,6 +66,7 @@ fn minimal_config(backend_addr: std::net::SocketAddr, listen_port: u16) -> Confi
         timeout: TimeoutConfig {
             upstream_connect_ms: Some(1000),
             proxy_idle_ms: 5000,
+            drain_delay_secs: 0,
             shutdown_secs: 1,
             tls_handshake_secs: 5,
             connection_handling_secs: 10,

--- a/huginn-proxy-lib/tests/integration.rs
+++ b/huginn-proxy-lib/tests/integration.rs
@@ -27,6 +27,7 @@ fn create_test_config(listen: &str, backends: Vec<Backend>) -> Config {
         timeout: TimeoutConfig {
             upstream_connect_ms: Some(5000),
             proxy_idle_ms: 60000,
+            drain_delay_secs: 0,
             shutdown_secs: 30,
             tls_handshake_secs: 15,
             connection_handling_secs: 300,

--- a/huginn-proxy-lib/tests/mod.rs
+++ b/huginn-proxy-lib/tests/mod.rs
@@ -4,4 +4,5 @@ mod fingerprinting;
 mod hot_reload;
 mod proxy;
 mod security;
+mod telemetry;
 mod tls;

--- a/huginn-proxy-lib/tests/proxy/mod.rs
+++ b/huginn-proxy-lib/tests/proxy/mod.rs
@@ -11,3 +11,4 @@ mod protocol;
 mod reload;
 mod resolve;
 mod router;
+mod shutdown;

--- a/huginn-proxy-lib/tests/proxy/shutdown.rs
+++ b/huginn-proxy-lib/tests/proxy/shutdown.rs
@@ -1,7 +1,11 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use huginn_proxy_lib::proxy::shutdown::wait_for_drain;
+use huginn_proxy_lib::proxy::shutdown::{
+    begin_shutdown, shutdown_channel, wait_for_drain, ShutdownPhase,
+};
+use huginn_proxy_lib::{NotReadyReason, Readiness};
+use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::watch;
 use tokio::time::{sleep, Duration};
 
@@ -41,4 +45,78 @@ async fn wait_for_drain_times_out_with_connections_still_active() {
     let (_tx, rx) = watch::channel(());
     let active = Arc::new(AtomicUsize::new(3));
     wait_for_drain(rx, active, 0).await;
+}
+
+/// Phase 1 must fail `/ready` while listeners keep accepting, so the load balancer has a
+/// window to drain the node before the listen socket closes.
+#[tokio::test]
+async fn drain_phase_fails_ready_without_stopping_accept_loops() {
+    let (Ok(mut sigterm), Ok(mut sigint)) =
+        (signal(SignalKind::terminate()), signal(SignalKind::interrupt()))
+    else {
+        panic!("failed to register signal handlers");
+    };
+
+    let readiness = Readiness::new();
+    readiness.mark_ready();
+    let (shutdown_tx, shutdown_rx) = shutdown_channel();
+
+    let drain = tokio::spawn({
+        let readiness = readiness.clone();
+        async move {
+            begin_shutdown(
+                "SIGTERM",
+                &readiness,
+                &shutdown_tx,
+                &mut sigterm,
+                &mut sigint,
+                Duration::from_millis(500),
+            )
+            .await;
+        }
+    });
+
+    sleep(Duration::from_millis(50)).await;
+
+    assert!(!drain.is_finished(), "still inside the drain delay");
+    assert_eq!(readiness.not_ready_reason(), Some(NotReadyReason::ProxyDraining));
+    assert_eq!(*shutdown_rx.borrow(), ShutdownPhase::Draining);
+    assert!(
+        !shutdown_rx.borrow().is_stopping(),
+        "accept loops break on Stopping only, so phase 1 keeps accepting"
+    );
+
+    assert!(drain.await.is_ok());
+}
+
+/// Default config (`drain_delay_secs = 0`) must behave as before the two-phase change:
+/// fail readiness and hand over to phase 2 without sleeping.
+#[tokio::test]
+async fn zero_drain_delay_hands_over_without_sleeping() {
+    let (Ok(mut sigterm), Ok(mut sigint)) =
+        (signal(SignalKind::terminate()), signal(SignalKind::interrupt()))
+    else {
+        panic!("failed to register signal handlers");
+    };
+
+    let readiness = Readiness::new();
+    readiness.mark_ready();
+    let (shutdown_tx, shutdown_rx) = shutdown_channel();
+
+    let handover = tokio::time::timeout(
+        Duration::from_secs(1),
+        begin_shutdown(
+            "SIGTERM",
+            &readiness,
+            &shutdown_tx,
+            &mut sigterm,
+            &mut sigint,
+            Duration::ZERO,
+        ),
+    )
+    .await;
+
+    assert!(handover.is_ok(), "phase 1 must hand over without sleeping");
+    assert_eq!(readiness.not_ready_reason(), Some(NotReadyReason::ProxyDraining));
+    assert_eq!(*shutdown_rx.borrow(), ShutdownPhase::Draining);
 }

--- a/huginn-proxy-lib/tests/proxy/shutdown.rs
+++ b/huginn-proxy-lib/tests/proxy/shutdown.rs
@@ -1,0 +1,44 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use huginn_proxy_lib::proxy::shutdown::wait_for_drain;
+use tokio::sync::watch;
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+async fn wait_for_drain_returns_immediately_when_idle() {
+    let (_tx, rx) = watch::channel(());
+    let active = Arc::new(AtomicUsize::new(0));
+    wait_for_drain(rx, active, 30).await;
+}
+
+#[tokio::test]
+async fn wait_for_drain_ignores_stale_notification() {
+    let (tx, rx) = watch::channel(());
+    let active = Arc::new(AtomicUsize::new(2));
+    let _ = tx.send(());
+
+    let waiter = tokio::spawn({
+        let active = Arc::clone(&active);
+        async move { wait_for_drain(rx, active, 5).await }
+    });
+
+    sleep(Duration::from_millis(50)).await;
+    assert!(!waiter.is_finished(), "stale notification must not complete drain");
+
+    active.store(1, Ordering::Relaxed);
+    let _ = tx.send(());
+    sleep(Duration::from_millis(20)).await;
+    assert!(!waiter.is_finished(), "must wait until the last connection");
+
+    active.store(0, Ordering::Relaxed);
+    let _ = tx.send(());
+    assert!(waiter.await.is_ok());
+}
+
+#[tokio::test]
+async fn wait_for_drain_times_out_with_connections_still_active() {
+    let (_tx, rx) = watch::channel(());
+    let active = Arc::new(AtomicUsize::new(3));
+    wait_for_drain(rx, active, 0).await;
+}

--- a/huginn-proxy-lib/tests/proxy_protocol.rs
+++ b/huginn-proxy-lib/tests/proxy_protocol.rs
@@ -383,6 +383,7 @@ async fn spawn_proxy_tls(
         timeout: TimeoutConfig {
             upstream_connect_ms: Some(5000),
             proxy_idle_ms: 30_000,
+            drain_delay_secs: 0,
             shutdown_secs: 3,
             tls_handshake_secs: 10,
             connection_handling_secs: 60,

--- a/huginn-proxy-lib/tests/telemetry/mod.rs
+++ b/huginn-proxy-lib/tests/telemetry/mod.rs
@@ -1,0 +1,1 @@
+mod readiness;

--- a/huginn-proxy-lib/tests/telemetry/readiness.rs
+++ b/huginn-proxy-lib/tests/telemetry/readiness.rs
@@ -23,3 +23,19 @@ fn mark_draining_uses_drain_reason() {
     assert!(!r.is_ready());
     assert_eq!(r.not_ready_reason(), Some(NotReadyReason::ProxyDraining));
 }
+
+#[test]
+fn mark_ready_cannot_cancel_draining() {
+    let r = Readiness::new();
+    r.mark_draining();
+    r.mark_ready();
+    assert!(!r.is_ready());
+    assert_eq!(r.not_ready_reason(), Some(NotReadyReason::ProxyDraining));
+}
+
+#[test]
+fn draining_before_listeners_are_up_reports_draining() {
+    let r = Readiness::new();
+    r.mark_draining();
+    assert_eq!(r.not_ready_reason(), Some(NotReadyReason::ProxyDraining));
+}

--- a/huginn-proxy-lib/tests/telemetry/readiness.rs
+++ b/huginn-proxy-lib/tests/telemetry/readiness.rs
@@ -1,10 +1,10 @@
-use huginn_proxy_lib::Readiness;
+use huginn_proxy_lib::{NotReadyReason, Readiness};
 
 #[test]
 fn starts_not_ready_as_starting() {
     let r = Readiness::new();
     assert!(!r.is_ready());
-    assert_eq!(r.not_ready_reason(), Some("proxy_starting"));
+    assert_eq!(r.not_ready_reason(), Some(NotReadyReason::ProxyStarting));
 }
 
 #[test]
@@ -21,5 +21,5 @@ fn mark_draining_uses_drain_reason() {
     r.mark_ready();
     r.mark_draining();
     assert!(!r.is_ready());
-    assert_eq!(r.not_ready_reason(), Some("proxy_draining"));
+    assert_eq!(r.not_ready_reason(), Some(NotReadyReason::ProxyDraining));
 }

--- a/huginn-proxy-lib/tests/telemetry/readiness.rs
+++ b/huginn-proxy-lib/tests/telemetry/readiness.rs
@@ -1,0 +1,25 @@
+use huginn_proxy_lib::Readiness;
+
+#[test]
+fn starts_not_ready_as_starting() {
+    let r = Readiness::new();
+    assert!(!r.is_ready());
+    assert_eq!(r.not_ready_reason(), Some("proxy_starting"));
+}
+
+#[test]
+fn mark_ready_clears_reason() {
+    let r = Readiness::new();
+    r.mark_ready();
+    assert!(r.is_ready());
+    assert_eq!(r.not_ready_reason(), None);
+}
+
+#[test]
+fn mark_draining_uses_drain_reason() {
+    let r = Readiness::new();
+    r.mark_ready();
+    r.mark_draining();
+    assert!(!r.is_ready());
+    assert_eq!(r.not_ready_reason(), Some("proxy_draining"));
+}

--- a/huginn-proxy/src/ebpf/mod.rs
+++ b/huginn-proxy/src/ebpf/mod.rs
@@ -114,7 +114,7 @@ async fn watch_pinned_maps(
     loop {
         tokio::select! {
             biased;
-            _ = shutdown_rx.wait_for(|shutting_down| *shutting_down) => {
+            _ = shutdown_rx.wait_for(|phase| phase.is_stopping()) => {
                 tracing::info!("eBPF pinned-map reconnect watcher shutting down");
                 break;
             }

--- a/huginn-proxy/src/main.rs
+++ b/huginn-proxy/src/main.rs
@@ -84,6 +84,7 @@ async fn main() -> Result<(), BoxError> {
 
     // Single shutdown channel shared by all background tasks
     let (shutdown_tx, shutdown_rx) = shutdown_channel();
+    let (obs_stop_tx, obs_stop_rx) = tokio::sync::watch::channel(false);
 
     // metrics (Arc<Metrics>) is kept alive for run(); only registry is moved into the spawn.
     let (metrics, registry) =
@@ -97,28 +98,23 @@ async fn main() -> Result<(), BoxError> {
         if let Some(metrics_port) = static_cfg.telemetry.metrics_port {
             info!(port = metrics_port, "Metrics initialized, starting observability server");
             let readiness_for_observability = readiness.clone();
-            let mut metrics_shutdown = shutdown_rx.clone();
             let handle = tokio::spawn(async move {
-                tokio::select! {
-                    biased;
-                    _ = metrics_shutdown.wait_for(|v| *v) => {
-                        info!("Metrics server shutting down");
-                    }
-                    result = start_observability_server(
-                        metrics_port,
-                        registry,
-                        readiness_for_observability,
-                    ) => {
-                        if let Err(e) = result {
-                            tracing::error!(error = %e, "Observability server error");
-                        }
-                    }
+                if let Err(e) = start_observability_server(
+                    metrics_port,
+                    registry,
+                    readiness_for_observability,
+                    obs_stop_rx,
+                )
+                .await
+                {
+                    tracing::error!(error = %e, "Observability server error");
                 }
             });
             Some(ServiceHandle { handle, name: ServiceName::MetricsServer })
         } else {
             info!("Metrics initialized (no metrics_port, Prometheus endpoint disabled)");
             drop(registry);
+            drop(obs_stop_rx);
             None
         };
 
@@ -146,7 +142,8 @@ async fn main() -> Result<(), BoxError> {
     )
     .await;
 
-    // Metrics server already received the shutdown signal (via shutdown_rx clone).
+    // Stop the observability server after drain so `/ready` stayed up through phase 1.
+    let _ = obs_stop_tx.send(true);
     if let Some(svc) = metrics_service {
         svc.shutdown(Duration::from_secs(2)).await;
     }


### PR DESCRIPTION
A new graceful shutdown mechanism was implemented that waits for existing connections to drain while continuing to accept new connections for a specified period, thereby allowing the load balancer to detect when the proxy has initiated the shutdown process.

## Shutdown sequence

SIGTERM / SIGINT
│
├─▶ phase = Draining                (server.rs)  /ready = 503
│     accept loops keep running
│     sleep drain_delay_secs (second signal skips)
│
├─▶ phase = Stopping
│     │
│     ├─▶ accept loops              wait_for(Stopping) → break
│     ├─▶ config-watcher            wait_for(Stopping) → break
│     ├─▶ ebpf-reconnect            wait_for(Stopping) → break
│     └─▶ connections               graceful_shutdown() then wait_for_drain
│
└─▶ observability server            stopped by main.rs after run() returns
