### PR TITLE
Reduce amount of internal handshake noise logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **TLS accept noise is `debug`.** Routine client noise (peer abort, unmatched SNI, non-TLS bytes) no longer logs at `warn`; timeouts and cert/mTLS failures stay `warn`. The `huginn-net-tls` target, which logs a JA4 parse `error` per non-TLS byte, is off in the default log filter and can be restored with `RUST_LOG`.
+- **TLS accept noise is `debug`.** Routine client noise (peer abort or reset, including during the ClientHello read, plus non-TLS bytes) no longer logs at `warn`. An unmatched SNI drops to `info` rather than `debug`, since it usually means a missing domain; timeouts and cert/mTLS failures stay `warn`. The `huginn-net-tls` target, which logs a JA4 parse `error` per non-TLS byte, is off in the default log filter and can be restored with `RUST_LOG`.
 - **`huginn_tls_handshake_errors_total` now carries `error_type`** (`client_hello_read`, `peer_eof`, `unmatched_sni`, `not_tls`, `handshake_timeout`, `other`), so causes demoted to `debug` stay diagnosable — a missing domain shows up as `unmatched_sni`. The label was already documented but never emitted; queries that sum the metric are unaffected.
 - **`/ready` 503 now reports why:** `proxy_starting` or `proxy_draining` (text: `STARTING` / `DRAINING`). With TCP fingerprinting, also `capture_*` (text: `NOCAPTURE`). The observability server stays up until after drain.
 - **Agent `/ready`** is attached + required pins + not draining (not pins-only). kubelet only; do not AND it with the proxy as a second load-balancer monitor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **TLS accept noise is `debug`.** Routine client noise (peer abort, unmatched SNI, non-TLS bytes) no longer logs at `warn`; timeouts and cert/mTLS failures stay `warn`. `huginn_tls_handshake_errors_total` is unchanged; `huginn-net-tls` JA4 parse logs above `debug` are suppressed.
 - **`/ready` 503 now reports why:** `proxy_starting` or `proxy_draining` (text: `STARTING` / `DRAINING`). With TCP fingerprinting, also `capture_*` (text: `NOCAPTURE`). The observability server stays up until after drain.
 - **Agent `/ready`** is attached + required pins + not draining (not pins-only). kubelet only; do not AND it with the proxy as a second load-balancer monitor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **TLS accept noise is `debug`.** Routine client noise (peer abort, unmatched SNI, non-TLS bytes) no longer logs at `warn`; timeouts and cert/mTLS failures stay `warn`. `huginn_tls_handshake_errors_total` is unchanged; `huginn-net-tls` JA4 parse logs above `debug` are suppressed.
+- **TLS accept noise is `debug`.** Routine client noise (peer abort, unmatched SNI, non-TLS bytes) no longer logs at `warn`; timeouts and cert/mTLS failures stay `warn`. `huginn-net-tls` JA4 parse logs above `debug` are suppressed.
+- **`huginn_tls_handshake_errors_total` now carries `error_type`** (`client_hello_read`, `peer_eof`, `unmatched_sni`, `not_tls`, `handshake_timeout`, `other`), so causes demoted to `debug` stay diagnosable — a missing domain shows up as `unmatched_sni`. The label was already documented but never emitted; queries that sum the metric are unaffected.
 - **`/ready` 503 now reports why:** `proxy_starting` or `proxy_draining` (text: `STARTING` / `DRAINING`). With TCP fingerprinting, also `capture_*` (text: `NOCAPTURE`). The observability server stays up until after drain.
 - **Agent `/ready`** is attached + required pins + not draining (not pins-only). kubelet only; do not AND it with the proxy as a second load-balancer monitor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ follows [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **TLS accept noise is `debug`.** Routine client noise (peer abort, unmatched SNI, non-TLS bytes) no longer logs at `warn`; timeouts and cert/mTLS failures stay `warn`. `huginn-net-tls` JA4 parse logs above `debug` are suppressed.
+- **TLS accept noise is `debug`.** Routine client noise (peer abort, unmatched SNI, non-TLS bytes) no longer logs at `warn`; timeouts and cert/mTLS failures stay `warn`. The `huginn-net-tls` target, which logs a JA4 parse `error` per non-TLS byte, is off in the default log filter and can be restored with `RUST_LOG`.
 - **`huginn_tls_handshake_errors_total` now carries `error_type`** (`client_hello_read`, `peer_eof`, `unmatched_sni`, `not_tls`, `handshake_timeout`, `other`), so causes demoted to `debug` stay diagnosable — a missing domain shows up as `unmatched_sni`. The label was already documented but never emitted; queries that sum the metric are unaffected.
 - **`/ready` 503 now reports why:** `proxy_starting` or `proxy_draining` (text: `STARTING` / `DRAINING`). With TCP fingerprinting, also `capture_*` (text: `NOCAPTURE`). The observability server stays up until after drain.
 - **Agent `/ready`** is attached + required pins + not draining (not pins-only). kubelet only; do not AND it with the proxy as a second load-balancer monitor.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log 0.4.34",
@@ -3256,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -965,7 +965,7 @@ fingerprint:
 | `level`       | string | `"info"` | Log level: `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`. Overridable with the `RUST_LOG` environment variable. |
 | `show_target` | bool   | `false`  | Include the Rust module path in log lines (useful for debugging).                                                     |
 
-Routine TLS client noise (peer abort, unmatched SNI, non-TLS bytes) logs at `debug`; handshake timeouts and cert/mTLS failures stay at `warn`. `huginn-net-tls` JA4 parse logs above `debug` are suppressed.
+Routine TLS client noise (peer abort, unmatched SNI, non-TLS bytes) logs at `debug`; handshake timeouts and cert/mTLS failures stay at `warn`. `huginn-net-tls` JA4 parse logs above `debug` are suppressed. All of them still increment `huginn_tls_handshake_errors_total{error_type=...}`, so the demoted causes remain visible in metrics — see `TELEMETRY.md`.
 
 When the proxy becomes ready, `info` logs one safe effective-config summary containing listener,
 domain, route, backend, trusted-proxy and max-connection counts plus key feature flags. At `debug`,

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -965,6 +965,8 @@ fingerprint:
 | `level`       | string | `"info"` | Log level: `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`. Overridable with the `RUST_LOG` environment variable. |
 | `show_target` | bool   | `false`  | Include the Rust module path in log lines (useful for debugging).                                                     |
 
+Routine TLS client noise (peer abort, unmatched SNI, non-TLS bytes) logs at `debug`; handshake timeouts and cert/mTLS failures stay at `warn`. `huginn-net-tls` JA4 parse logs above `debug` are suppressed.
+
 When the proxy becomes ready, `info` logs one safe effective-config summary containing listener,
 domain, route, backend, trusted-proxy and max-connection counts plus key feature flags. At `debug`,
 it also logs the complete `EffectiveConfigView` as compact JSON. The debug view uses the same

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -965,7 +965,11 @@ fingerprint:
 | `level`       | string | `"info"` | Log level: `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`. Overridable with the `RUST_LOG` environment variable. |
 | `show_target` | bool   | `false`  | Include the Rust module path in log lines (useful for debugging).                                                     |
 
-Routine TLS client noise (peer abort, unmatched SNI, non-TLS bytes) logs at `debug`; handshake timeouts and cert/mTLS failures stay at `warn`. `huginn-net-tls` JA4 parse logs above `debug` are suppressed. All of them still increment `huginn_tls_handshake_errors_total{error_type=...}`, so the demoted causes remain visible in metrics — see `TELEMETRY.md`.
+Routine TLS client noise (peer abort, unmatched SNI, non-TLS bytes) logs at `debug`; handshake timeouts and cert/mTLS failures stay at `warn`. All of them still increment `huginn_tls_handshake_errors_total{error_type=...}`, so the demoted causes remain visible in metrics — see `TELEMETRY.md`.
+
+The `huginn-net-tls` target is off by default, because it logs a JA4 parse `error` for every
+non-TLS byte that reaches the TLS port. It is a default rather than a hard filter: `RUST_LOG`
+replaces the whole filter, so `RUST_LOG=info,huginn_net_tls=debug` brings those events back.
 
 When the proxy becomes ready, `info` logs one safe effective-config summary containing listener,
 domain, route, backend, trusted-proxy and max-connection counts plus key feature flags. At `debug`,

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -965,7 +965,11 @@ fingerprint:
 | `level`       | string | `"info"` | Log level: `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`. Overridable with the `RUST_LOG` environment variable. |
 | `show_target` | bool   | `false`  | Include the Rust module path in log lines (useful for debugging).                                                     |
 
-Routine TLS client noise (peer abort, unmatched SNI, non-TLS bytes) logs at `debug`; handshake timeouts and cert/mTLS failures stay at `warn`. All of them still increment `huginn_tls_handshake_errors_total{error_type=...}`, so the demoted causes remain visible in metrics — see `TELEMETRY.md`.
+Routine TLS client noise (peer abort or reset, non-TLS bytes) logs at `debug`. An unmatched SNI logs at
+`info`, because it usually means a domain is missing from the config rather than a client misbehaving.
+Handshake timeouts and cert/mTLS failures stay at `warn`. All of them increment
+`huginn_tls_handshake_errors_total{error_type=...}`, so the demoted causes remain visible in metrics — see
+`TELEMETRY.md`.
 
 The `huginn-net-tls` target is off by default, because it logs a JA4 parse `error` for every
 non-TLS byte that reaches the TLS port. It is a default rather than a hard filter: `RUST_LOG`

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -317,14 +317,15 @@ sum by (route) (rate(huginn_requests_total{status_code=~"5.."}[5m]))
 
 - `tls_version`: TLS version negotiated (`TLS1.2`, `TLS1.3`)
 - `cipher_suite`: TLS cipher suite used (e.g., `TLS_AES_256_GCM_SHA384`)
-- `error_type`: Why the handshake failed. Bounded set: `client_hello_read`, `peer_eof` (client went away
-  mid-handshake), `unmatched_sni` (no domain matched the ClientHello SNI), `not_tls` (non-TLS bytes on the
-  TLS port), `handshake_timeout`, `other` (certificate/mTLS/protocol failure).
+- `error_type`: Why the handshake failed. Bounded set: `peer_eof` (client went away mid-handshake, by clean
+  close or reset), `unmatched_sni` (no domain matched the ClientHello SNI), `not_tls` (non-TLS bytes on the
+  TLS port), `handshake_timeout`, `client_hello_read` (I/O fault reading the ClientHello that is *not* the
+  peer disconnecting), `other` (certificate/mTLS/protocol failure).
 - `timeout_type`: Timeout type (`tls_handshake`, `connection`, `idle`)
 
-`peer_eof`, `unmatched_sni` and `not_tls` are routine on a public listener and log at `debug`, so this label
-is the primary signal for them. A sustained `unmatched_sni` rate against a name you expect to serve usually
-means the domain is missing from the config rather than scanner traffic.
+`peer_eof` and `not_tls` are routine on a public listener and log at `debug`, so this label is the primary
+signal for them. `unmatched_sni` logs at `info` instead: a sustained rate against a name you expect to serve
+usually means the domain is missing from the config rather than scanner traffic.
 
 **Example queries**:
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -317,8 +317,14 @@ sum by (route) (rate(huginn_requests_total{status_code=~"5.."}[5m]))
 
 - `tls_version`: TLS version negotiated (`TLS1.2`, `TLS1.3`)
 - `cipher_suite`: TLS cipher suite used (e.g., `TLS_AES_256_GCM_SHA384`)
-- `error_type`: Error type (`handshake_timeout`, `invalid_certificate`, `protocol_error`, etc.)
+- `error_type`: Why the handshake failed. Bounded set: `client_hello_read`, `peer_eof` (client went away
+  mid-handshake), `unmatched_sni` (no domain matched the ClientHello SNI), `not_tls` (non-TLS bytes on the
+  TLS port), `handshake_timeout`, `other` (certificate/mTLS/protocol failure).
 - `timeout_type`: Timeout type (`tls_handshake`, `connection`, `idle`)
+
+`peer_eof`, `unmatched_sni` and `not_tls` are routine on a public listener and log at `debug`, so this label
+is the primary signal for them. A sustained `unmatched_sni` rate against a name you expect to serve usually
+means the domain is missing from the config rather than scanner traffic.
 
 **Example queries**:
 
@@ -334,6 +340,12 @@ sum by (cipher_suite) (rate(huginn_tls_handshakes_total[5m]))
 
 # TLS error rate
 rate(huginn_tls_handshake_errors_total[5m])
+
+# TLS errors by cause: separates real failures from scanner noise
+sum by (error_type) (rate(huginn_tls_handshake_errors_total[5m]))
+
+# Handshake failures worth paging on (excludes routine client noise)
+sum(rate(huginn_tls_handshake_errors_total{error_type=~"other|handshake_timeout"}[5m]))
 
 # P95 handshake duration
 histogram_quantile(0.95, rate(huginn_tls_handshake_duration_seconds_bucket[5m]))
@@ -679,7 +691,7 @@ sum by (protocol) (rate(huginn_mtls_connections_total[5m]))
 **Note**:
 
 - This metric only counts successful TLS handshakes where a client certificate was present and verified.
-- mTLS verification failures are captured in `huginn_tls_handshake_errors_total`.
+- mTLS verification failures are captured in `huginn_tls_handshake_errors_total{error_type="other"}`.
 - When mTLS is required but client certificate is invalid/absent, the TLS handshake fails before this metric is
   recorded. In that case the `TLS accept failed` / `TLS handshake timeout` logs carry `mtls=true` and the
   selected `sni`, so a failure against a domain that required a client certificate can be attributed per-domain (the

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -681,7 +681,7 @@ sum by (protocol) (rate(huginn_mtls_connections_total[5m]))
 - This metric only counts successful TLS handshakes where a client certificate was present and verified.
 - mTLS verification failures are captured in `huginn_tls_handshake_errors_total`.
 - When mTLS is required but client certificate is invalid/absent, the TLS handshake fails before this metric is
-  recorded. In that case the `TLS accept failed` / `TLS handshake timeout` **warning logs** carry `mtls=true` and the
+  recorded. In that case the `TLS accept failed` / `TLS handshake timeout` logs carry `mtls=true` and the
   selected `sni`, so a failure against a domain that required a client certificate can be attributed per-domain (the
   mTLS flag comes from the per-SNI config picked from the ClientHello, so it is known even though the handshake never
   completed).

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -327,6 +327,11 @@ sum by (route) (rate(huginn_requests_total{status_code=~"5.."}[5m]))
 signal for them. `unmatched_sni` logs at `info` instead: a sustained rate against a name you expect to serve
 usually means the domain is missing from the config rather than scanner traffic.
 
+A handshake timeout increments **both** `huginn_tls_handshake_errors_total{error_type="handshake_timeout"}`
+and `huginn_timeouts_total{timeout_type="tls_handshake"}`. This is deliberate, so that summing
+`huginn_tls_handshake_errors_total` by `error_type` still adds up to the total handshake failures. Do not add
+the two metrics together in a dashboard — you would count every timeout twice.
+
 **Example queries**:
 
 ```promql

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -9,6 +9,7 @@ use crate::proxy::handler::request::handle_proxy_request;
 use crate::proxy::synthetic_response::synthetic_error_response;
 use crate::proxy::ClientPool;
 use crate::telemetry::Metrics;
+use crate::tls::is_expected_tls_accept_failure;
 use crate::tls::record_tls_handshake_metrics;
 use crate::tls::setup::SharedServerCrypto;
 use http::StatusCode;
@@ -18,7 +19,7 @@ use tokio::net::TcpStream;
 use tokio::time::Instant;
 use tokio_rustls::rustls::server::Acceptor;
 use tokio_rustls::LazyConfigAcceptor;
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// Configuration for handling TLS connections
 pub struct TlsConnectionConfig {
@@ -65,6 +66,7 @@ pub async fn handle_tls_connection(
         // client that omitted a required client cert). Mirrors rpxy's failure log.
         let mut selected_sni: Option<String> = None;
         let mut selected_mtls = false;
+        let mut unmatched_sni = false;
         // Two-phase handshake: `LazyConfigAcceptor` reads the ClientHello (replayed
         // from the prefix), then we pick the per-SNI `ServerConfig` and finish. The
         // whole exchange is bounded by the single handshake timeout.
@@ -84,7 +86,10 @@ pub async fn handle_tls_connection(
                         selected_mtls = picked.is_mutual_tls;
                         picked.config
                     }
-                    None => crypto.reject_config(),
+                    None => {
+                        unmatched_sni = true;
+                        crypto.reject_config()
+                    }
                 }
             };
             start.into_stream(server_config).await
@@ -95,7 +100,11 @@ pub async fn handle_tls_connection(
         let tls = match tls_accept_result {
             Ok(Ok(tls)) => tls,
             Ok(Err(e)) => {
-                warn!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed");
+                if is_expected_tls_accept_failure(&e, unmatched_sni) {
+                    debug!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed");
+                } else {
+                    warn!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed");
+                }
                 metrics.record_tls_handshake_error();
                 return;
             }

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -12,7 +12,7 @@ use crate::telemetry::metrics::values;
 use crate::telemetry::Metrics;
 use crate::tls::record_tls_handshake_metrics;
 use crate::tls::setup::SharedServerCrypto;
-use crate::tls::TlsAcceptFailure;
+use crate::tls::{FailureSeverity, TlsAcceptFailure};
 use http::StatusCode;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
@@ -20,7 +20,7 @@ use tokio::net::TcpStream;
 use tokio::time::Instant;
 use tokio_rustls::rustls::server::Acceptor;
 use tokio_rustls::LazyConfigAcceptor;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// Configuration for handling TLS connections
 pub struct TlsConnectionConfig {
@@ -55,8 +55,26 @@ pub async fn handle_tls_connection(
             match read_client_hello(&mut stream, Arc::clone(&metrics)).await {
                 Ok(v) => v,
                 Err(e) => {
-                    warn!(?peer, error = %e, "failed to read client hello");
-                    metrics.record_tls_handshake_error(values::TLS_ERROR_CLIENT_HELLO);
+                    // A peer that vanished mid-read is the same noise the accept path
+                    // below demotes; anything else is a genuine read fault worth a warn.
+                    let failure = TlsAcceptFailure::classify(&e, false);
+                    match failure.severity() {
+                        FailureSeverity::Debug => {
+                            debug!(?peer, error = %e, "failed to read client hello")
+                        }
+                        FailureSeverity::Info => {
+                            info!(?peer, error = %e, "failed to read client hello")
+                        }
+                        FailureSeverity::Warn => {
+                            warn!(?peer, error = %e, "failed to read client hello")
+                        }
+                    }
+                    let error_type = if failure.is_expected() {
+                        failure.error_type()
+                    } else {
+                        values::TLS_ERROR_CLIENT_HELLO
+                    };
+                    metrics.record_tls_handshake_error(error_type);
                     return;
                 }
             };
@@ -102,10 +120,16 @@ pub async fn handle_tls_connection(
             Ok(Ok(tls)) => tls,
             Ok(Err(e)) => {
                 let failure = TlsAcceptFailure::classify(&e, unmatched_sni);
-                if failure.is_expected() {
-                    debug!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed");
-                } else {
-                    warn!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed");
+                match failure.severity() {
+                    FailureSeverity::Debug => {
+                        debug!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed")
+                    }
+                    FailureSeverity::Info => {
+                        info!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed")
+                    }
+                    FailureSeverity::Warn => {
+                        warn!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed")
+                    }
                 }
                 metrics.record_tls_handshake_error(failure.error_type());
                 return;

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -8,10 +8,11 @@ use crate::proxy::connection::{PrefixedStream, TlsConnectionGuard};
 use crate::proxy::handler::request::handle_proxy_request;
 use crate::proxy::synthetic_response::synthetic_error_response;
 use crate::proxy::ClientPool;
+use crate::telemetry::metrics::values;
 use crate::telemetry::Metrics;
-use crate::tls::is_expected_tls_accept_failure;
 use crate::tls::record_tls_handshake_metrics;
 use crate::tls::setup::SharedServerCrypto;
+use crate::tls::TlsAcceptFailure;
 use http::StatusCode;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use hyper_util::server::conn::auto::Builder as ConnBuilder;
@@ -55,7 +56,7 @@ pub async fn handle_tls_connection(
                 Ok(v) => v,
                 Err(e) => {
                     warn!(?peer, error = %e, "failed to read client hello");
-                    metrics.tls_handshake_errors_total.add(1, &[]);
+                    metrics.record_tls_handshake_error(values::TLS_ERROR_CLIENT_HELLO);
                     return;
                 }
             };
@@ -100,18 +101,19 @@ pub async fn handle_tls_connection(
         let tls = match tls_accept_result {
             Ok(Ok(tls)) => tls,
             Ok(Err(e)) => {
-                if is_expected_tls_accept_failure(&e, unmatched_sni) {
+                let failure = TlsAcceptFailure::classify(&e, unmatched_sni);
+                if failure.is_expected() {
                     debug!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed");
                 } else {
                     warn!(?peer, sni = sni_field, mtls = selected_mtls, error = %e, "TLS accept failed");
                 }
-                metrics.record_tls_handshake_error();
+                metrics.record_tls_handshake_error(failure.error_type());
                 return;
             }
             Err(_) => {
                 warn!(?peer, sni = sni_field, mtls = selected_mtls, "TLS handshake timeout");
                 metrics.record_timeout("tls_handshake");
-                metrics.record_tls_handshake_error();
+                metrics.record_tls_handshake_error(values::TLS_ERROR_HANDSHAKE_TIMEOUT);
                 return;
             }
         };

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -55,8 +55,6 @@ pub async fn handle_tls_connection(
             match read_client_hello(&mut stream, Arc::clone(&metrics)).await {
                 Ok(v) => v,
                 Err(e) => {
-                    // A peer that vanished mid-read is the same noise the accept path
-                    // below demotes; anything else is a genuine read fault worth a warn.
                     let failure = TlsAcceptFailure::classify(&e, false);
                     match failure.severity() {
                         FailureSeverity::Debug => {

--- a/huginn-proxy-lib/src/proxy/transport/tls.rs
+++ b/huginn-proxy-lib/src/proxy/transport/tls.rs
@@ -134,7 +134,7 @@ pub async fn handle_tls_connection(
             }
             Err(_) => {
                 warn!(?peer, sni = sni_field, mtls = selected_mtls, "TLS handshake timeout");
-                metrics.record_timeout("tls_handshake");
+                metrics.record_timeout(values::TIMEOUT_TLS_HANDSHAKE);
                 metrics.record_tls_handshake_error(values::TLS_ERROR_HANDSHAKE_TIMEOUT);
                 return;
             }

--- a/huginn-proxy-lib/src/telemetry/metrics.rs
+++ b/huginn-proxy-lib/src/telemetry/metrics.rs
@@ -44,6 +44,14 @@ pub mod values {
     pub const REASON_SHUTDOWN: &str = "shutdown";
     pub const HEALTH_PROBE_OK: &str = "ok";
     pub const HEALTH_PROBE_FAIL: &str = "fail";
+    /// TLS failure kinds for `tls_handshake_errors_total{error_type=...}`. Bounded set:
+    /// every accept failure maps to exactly one of these.
+    pub const TLS_ERROR_CLIENT_HELLO: &str = "client_hello_read";
+    pub const TLS_ERROR_PEER_EOF: &str = "peer_eof";
+    pub const TLS_ERROR_UNMATCHED_SNI: &str = "unmatched_sni";
+    pub const TLS_ERROR_NOT_TLS: &str = "not_tls";
+    pub const TLS_ERROR_HANDSHAKE_TIMEOUT: &str = "handshake_timeout";
+    pub const TLS_ERROR_OTHER: &str = "other";
     /// PROXY protocol drop reasons for `proxy_protocol_dropped_total{reason=...}`.
     pub const PROXY_PROTOCOL_DROP_UNTRUSTED_REQUIRE: &str = "untrusted_require";
     pub const PROXY_PROTOCOL_DROP_BAD_HEADER: &str = "bad_header";
@@ -690,8 +698,14 @@ impl Metrics {
             .add(1, &[KeyValue::new(labels::ERROR_TYPE, error_type.to_string())]);
     }
 
-    pub fn record_tls_handshake_error(&self) {
-        self.tls_handshake_errors_total.add(1, &[]);
+    /// Count one failed TLS handshake under `error_type`.
+    ///
+    /// `error_type` comes from a bounded set (`values::TLS_ERROR_*`), so a config
+    /// mistake such as a missing domain stays distinguishable from scanner traffic
+    /// even though both are logged at `debug`.
+    pub fn record_tls_handshake_error(&self, error_type: &str) {
+        self.tls_handshake_errors_total
+            .add(1, &[KeyValue::new(labels::ERROR_TYPE, error_type.to_string())]);
     }
 
     pub fn record_timeout(&self, timeout_type: &str) {

--- a/huginn-proxy-lib/src/telemetry/mod.rs
+++ b/huginn-proxy-lib/src/telemetry/mod.rs
@@ -12,4 +12,6 @@ pub use metrics::{init_metrics, values, Metrics};
 pub use metrics_handler::handle_metrics;
 pub use readiness::{GateState, NotReadyReason, Readiness, ReadinessGate};
 pub use server::start_observability_server;
-pub use tracing::{init_tracing_with_otel, init_validation_tracing, shutdown_tracing};
+pub use tracing::{
+    default_log_filter, init_tracing_with_otel, init_validation_tracing, shutdown_tracing,
+};

--- a/huginn-proxy-lib/src/telemetry/tracing.rs
+++ b/huginn-proxy-lib/src/telemetry/tracing.rs
@@ -1,20 +1,19 @@
-use tracing::Metadata;
-use tracing_subscriber::filter::filter_fn;
-use tracing_subscriber::filter::FilterFn;
 use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
 
-/// `huginn-net-tls` logs `ERROR TLS plaintext parsing failed` for HTTP/garbage on the
-/// TLS port (JA4 parse). That is client noise, not a proxy failure. Keep its
-/// `debug`/`trace` lines when the process log level allows them.
-fn suppress_huginn_net_tls_noise() -> FilterFn<impl Fn(&Metadata<'_>) -> bool + Clone> {
-    filter_fn(|meta: &Metadata<'_>| {
-        if meta.target().starts_with("huginn_net_tls") {
-            return *meta.level() > tracing::Level::INFO;
-        }
-        true
-    })
+/// Targets silenced by default because they log client-controlled input as failures.
+///
+/// `huginn-net-tls` emits `ERROR TLS plaintext parsing failed` for every HTTP request or
+/// stray byte that reaches the TLS port (JA4 parse), which is client noise rather than a
+/// proxy fault.
+const QUIET_TARGETS: &str = "huginn_net_tls=off";
+
+/// Compose the log filter used when `RUST_LOG` is unset.
+///
+/// `RUST_LOG` replaces this string wholesale, which is the escape hatch for the targets in
+/// [`QUIET_TARGETS`]: `RUST_LOG=info,huginn_net_tls=debug` brings those events back.
+pub fn default_log_filter(base: &str) -> String {
+    format!("{base},{QUIET_TARGETS}")
 }
 
 /// Initialize warning-level tracing for one-shot CLI validation.
@@ -23,11 +22,10 @@ fn suppress_huginn_net_tls_noise() -> FilterFn<impl Fn(&Metadata<'_>) -> bool + 
 /// effective configuration.
 pub fn init_validation_tracing() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_log_filter("warn")));
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_target(false)
-        .with_writer(std::io::stderr)
-        .with_filter(suppress_huginn_net_tls_noise());
+        .with_writer(std::io::stderr);
     let subscriber = Registry::default().with(env_filter).with(fmt_layer);
 
     tracing::subscriber::set_global_default(subscriber)
@@ -41,12 +39,10 @@ pub fn init_tracing_with_otel(
     show_target: bool,
     otel_log_level: String,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let filter_str = format!("{log_level},opentelemetry={otel_log_level}");
+    let filter_str = default_log_filter(&format!("{log_level},opentelemetry={otel_log_level}"));
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(filter_str));
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_target(show_target)
-        .with_filter(suppress_huginn_net_tls_noise());
+    let fmt_layer = tracing_subscriber::fmt::layer().with_target(show_target);
 
     let subscriber = Registry::default().with(env_filter).with(fmt_layer);
 

--- a/huginn-proxy-lib/src/telemetry/tracing.rs
+++ b/huginn-proxy-lib/src/telemetry/tracing.rs
@@ -1,5 +1,21 @@
+use tracing::Metadata;
+use tracing_subscriber::filter::filter_fn;
+use tracing_subscriber::filter::FilterFn;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Layer;
 use tracing_subscriber::Registry;
+
+/// `huginn-net-tls` logs `ERROR TLS plaintext parsing failed` for HTTP/garbage on the
+/// TLS port (JA4 parse). That is client noise, not a proxy failure. Keep its
+/// `debug`/`trace` lines when the process log level allows them.
+fn suppress_huginn_net_tls_noise() -> FilterFn<impl Fn(&Metadata<'_>) -> bool + Clone> {
+    filter_fn(|meta: &Metadata<'_>| {
+        if meta.target().starts_with("huginn_net_tls") {
+            return *meta.level() > tracing::Level::INFO;
+        }
+        true
+    })
+}
 
 /// Initialize warning-level tracing for one-shot CLI validation.
 ///
@@ -10,7 +26,8 @@ pub fn init_validation_tracing() -> Result<(), Box<dyn std::error::Error + Send 
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"));
     let fmt_layer = tracing_subscriber::fmt::layer()
         .with_target(false)
-        .with_writer(std::io::stderr);
+        .with_writer(std::io::stderr)
+        .with_filter(suppress_huginn_net_tls_noise());
     let subscriber = Registry::default().with(env_filter).with(fmt_layer);
 
     tracing::subscriber::set_global_default(subscriber)
@@ -27,7 +44,9 @@ pub fn init_tracing_with_otel(
     let filter_str = format!("{log_level},opentelemetry={otel_log_level}");
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(filter_str));
-    let fmt_layer = tracing_subscriber::fmt::layer().with_target(show_target);
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_target(show_target)
+        .with_filter(suppress_huginn_net_tls_noise());
 
     let subscriber = Registry::default().with(env_filter).with(fmt_layer);
 

--- a/huginn-proxy-lib/src/telemetry/tracing.rs
+++ b/huginn-proxy-lib/src/telemetry/tracing.rs
@@ -10,8 +10,8 @@ const QUIET_TARGETS: &str = "huginn_net_tls=off";
 
 /// Compose the log filter used when `RUST_LOG` is unset.
 ///
-/// `RUST_LOG` replaces this string wholesale, which is the escape hatch for the targets in
-/// [`QUIET_TARGETS`]: `RUST_LOG=info,huginn_net_tls=debug` brings those events back.
+/// Appends `huginn_net_tls=off`. `RUST_LOG` replaces this string wholesale, so
+/// `RUST_LOG=info,huginn_net_tls=debug` brings those events back.
 pub fn default_log_filter(base: &str) -> String {
     format!("{base},{QUIET_TARGETS}")
 }

--- a/huginn-proxy-lib/src/tls/accept_failure.rs
+++ b/huginn-proxy-lib/src/tls/accept_failure.rs
@@ -75,7 +75,8 @@ impl TlsAcceptFailure {
     pub fn is_expected(self) -> bool {
         !matches!(self.severity(), FailureSeverity::Warn)
     }
-    
+
+    /// Value for the `error_type` label on `huginn_tls_handshake_errors_total`.
     pub fn error_type(self) -> &'static str {
         match self {
             Self::PeerEof => values::TLS_ERROR_PEER_EOF,

--- a/huginn-proxy-lib/src/tls/accept_failure.rs
+++ b/huginn-proxy-lib/src/tls/accept_failure.rs
@@ -9,11 +9,12 @@ use crate::telemetry::metrics::values;
 ///
 /// Unmatched SNI is decided by the accept path (`ServerCryptoMap::select` returned
 /// `None`), not by parsing rustls `Error::General`. `tokio-rustls` maps a
-/// mid-handshake TCP close to `ErrorKind::UnexpectedEof`. Non-TLS bytes become
-/// `InvalidMessage::InvalidContentType`.
+/// mid-handshake TCP close to `ErrorKind::UnexpectedEof`, while a peer that resets the
+/// connection surfaces as `ConnectionReset`/`ConnectionAborted`/`BrokenPipe`. Non-TLS
+/// bytes become `InvalidMessage::InvalidContentType`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TlsAcceptFailure {
-    /// Peer went away mid-handshake.
+    /// Peer went away mid-handshake, whether by clean close or by reset.
     PeerEof,
     /// No domain matched the ClientHello SNI.
     UnmatchedSni,
@@ -23,6 +24,19 @@ pub enum TlsAcceptFailure {
     Other,
 }
 
+/// How loudly an accept failure is reported.
+///
+/// Three levels rather than a quiet/loud flag because an unmatched SNI sits between the
+/// two: it is not a proxy fault, but it is usually a domain missing from the config, so
+/// hiding it at `debug` would make a real misconfiguration invisible. `rpxy` draws the
+/// same line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailureSeverity {
+    Debug,
+    Info,
+    Warn,
+}
+
 impl TlsAcceptFailure {
     /// Classify a `tokio-rustls` accept error. `unmatched_sni` wins over the transport
     /// error because a rejected SNI is the cause of whatever alert or close follows.
@@ -30,7 +44,15 @@ impl TlsAcceptFailure {
         if unmatched_sni {
             return Self::UnmatchedSni;
         }
-        if err.kind() == ErrorKind::UnexpectedEof {
+        // Connect-then-reset is what most scanners and some load-balancer health checks
+        // do, so it must be classified alongside a clean mid-handshake close.
+        if matches!(
+            err.kind(),
+            ErrorKind::UnexpectedEof
+                | ErrorKind::ConnectionReset
+                | ErrorKind::ConnectionAborted
+                | ErrorKind::BrokenPipe
+        ) {
             return Self::PeerEof;
         }
         match rustls_error(err) {
@@ -39,9 +61,19 @@ impl TlsAcceptFailure {
         }
     }
 
-    /// Routine client/scanner behavior rather than a proxy or certificate bug.
+    /// Log level for this failure.
+    pub fn severity(self) -> FailureSeverity {
+        match self {
+            Self::PeerEof | Self::NotTls => FailureSeverity::Debug,
+            Self::UnmatchedSni => FailureSeverity::Info,
+            Self::Other => FailureSeverity::Warn,
+        }
+    }
+
+    /// Routine client/scanner behavior rather than a proxy or certificate bug. Derived
+    /// from [`Self::severity`] so the two cannot drift.
     pub fn is_expected(self) -> bool {
-        !matches!(self, Self::Other)
+        !matches!(self.severity(), FailureSeverity::Warn)
     }
 
     /// Value for the `error_type` label on `huginn_tls_handshake_errors_total`.

--- a/huginn-proxy-lib/src/tls/accept_failure.rs
+++ b/huginn-proxy-lib/src/tls/accept_failure.rs
@@ -75,8 +75,7 @@ impl TlsAcceptFailure {
     pub fn is_expected(self) -> bool {
         !matches!(self.severity(), FailureSeverity::Warn)
     }
-
-    /// Value for the `error_type` label on `huginn_tls_handshake_errors_total`.
+    
     pub fn error_type(self) -> &'static str {
         match self {
             Self::PeerEof => values::TLS_ERROR_PEER_EOF,

--- a/huginn-proxy-lib/src/tls/accept_failure.rs
+++ b/huginn-proxy-lib/src/tls/accept_failure.rs
@@ -1,0 +1,23 @@
+use std::io::{Error as IoError, ErrorKind};
+
+use tokio_rustls::rustls::{Error as RustlsError, InvalidMessage};
+
+/// Peer/scanner TLS failures that are not a proxy or certificate bug.
+///
+/// Unmatched SNI is decided by the accept path (`ServerCryptoMap::select` returned
+/// `None`), not by parsing rustls `Error::General`. `tokio-rustls` maps a
+/// mid-handshake TCP close to `ErrorKind::UnexpectedEof`. Non-TLS bytes become
+/// `InvalidMessage::InvalidContentType`.
+pub fn is_expected_tls_accept_failure(err: &IoError, unmatched_sni: bool) -> bool {
+    if unmatched_sni || err.kind() == ErrorKind::UnexpectedEof {
+        return true;
+    }
+    matches!(
+        rustls_error(err),
+        Some(RustlsError::InvalidMessage(InvalidMessage::InvalidContentType))
+    )
+}
+
+fn rustls_error(err: &IoError) -> Option<&RustlsError> {
+    err.get_ref()?.downcast_ref()
+}

--- a/huginn-proxy-lib/src/tls/accept_failure.rs
+++ b/huginn-proxy-lib/src/tls/accept_failure.rs
@@ -2,20 +2,57 @@ use std::io::{Error as IoError, ErrorKind};
 
 use tokio_rustls::rustls::{Error as RustlsError, InvalidMessage};
 
-/// Peer/scanner TLS failures that are not a proxy or certificate bug.
+use crate::telemetry::metrics::values;
+
+/// Why a TLS accept failed, resolved once and used for both the log level and the
+/// `error_type` metric label so the two can never disagree.
 ///
 /// Unmatched SNI is decided by the accept path (`ServerCryptoMap::select` returned
 /// `None`), not by parsing rustls `Error::General`. `tokio-rustls` maps a
 /// mid-handshake TCP close to `ErrorKind::UnexpectedEof`. Non-TLS bytes become
 /// `InvalidMessage::InvalidContentType`.
-pub fn is_expected_tls_accept_failure(err: &IoError, unmatched_sni: bool) -> bool {
-    if unmatched_sni || err.kind() == ErrorKind::UnexpectedEof {
-        return true;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TlsAcceptFailure {
+    /// Peer went away mid-handshake.
+    PeerEof,
+    /// No domain matched the ClientHello SNI.
+    UnmatchedSni,
+    /// Non-TLS bytes on the TLS port.
+    NotTls,
+    /// Certificate, mTLS or protocol failure: a real proxy-side problem.
+    Other,
+}
+
+impl TlsAcceptFailure {
+    /// Classify a `tokio-rustls` accept error. `unmatched_sni` wins over the transport
+    /// error because a rejected SNI is the cause of whatever alert or close follows.
+    pub fn classify(err: &IoError, unmatched_sni: bool) -> Self {
+        if unmatched_sni {
+            return Self::UnmatchedSni;
+        }
+        if err.kind() == ErrorKind::UnexpectedEof {
+            return Self::PeerEof;
+        }
+        match rustls_error(err) {
+            Some(RustlsError::InvalidMessage(InvalidMessage::InvalidContentType)) => Self::NotTls,
+            _ => Self::Other,
+        }
     }
-    matches!(
-        rustls_error(err),
-        Some(RustlsError::InvalidMessage(InvalidMessage::InvalidContentType))
-    )
+
+    /// Routine client/scanner behavior rather than a proxy or certificate bug.
+    pub fn is_expected(self) -> bool {
+        !matches!(self, Self::Other)
+    }
+
+    /// Value for the `error_type` label on `huginn_tls_handshake_errors_total`.
+    pub fn error_type(self) -> &'static str {
+        match self {
+            Self::PeerEof => values::TLS_ERROR_PEER_EOF,
+            Self::UnmatchedSni => values::TLS_ERROR_UNMATCHED_SNI,
+            Self::NotTls => values::TLS_ERROR_NOT_TLS,
+            Self::Other => values::TLS_ERROR_OTHER,
+        }
+    }
 }
 
 fn rustls_error(err: &IoError) -> Option<&RustlsError> {

--- a/huginn-proxy-lib/src/tls/mod.rs
+++ b/huginn-proxy-lib/src/tls/mod.rs
@@ -2,7 +2,7 @@ pub mod accept_failure;
 pub mod cert_reload;
 pub mod metrics;
 pub mod setup;
-pub use accept_failure::TlsAcceptFailure;
+pub use accept_failure::{FailureSeverity, TlsAcceptFailure};
 pub use cert_reload::{build_server_crypto_map, cert_entries_from_domains, reload_server_crypto};
 pub use huginn_certs::cipher_suites::{is_cipher_suite_supported, supported_cipher_suites};
 pub use huginn_certs::kx_groups::{is_curve_supported, supported_curves};

--- a/huginn-proxy-lib/src/tls/mod.rs
+++ b/huginn-proxy-lib/src/tls/mod.rs
@@ -1,6 +1,8 @@
+pub mod accept_failure;
 pub mod cert_reload;
 pub mod metrics;
 pub mod setup;
+pub use accept_failure::is_expected_tls_accept_failure;
 pub use cert_reload::{build_server_crypto_map, cert_entries_from_domains, reload_server_crypto};
 pub use huginn_certs::cipher_suites::{is_cipher_suite_supported, supported_cipher_suites};
 pub use huginn_certs::kx_groups::{is_curve_supported, supported_curves};

--- a/huginn-proxy-lib/src/tls/mod.rs
+++ b/huginn-proxy-lib/src/tls/mod.rs
@@ -2,7 +2,7 @@ pub mod accept_failure;
 pub mod cert_reload;
 pub mod metrics;
 pub mod setup;
-pub use accept_failure::is_expected_tls_accept_failure;
+pub use accept_failure::TlsAcceptFailure;
 pub use cert_reload::{build_server_crypto_map, cert_entries_from_domains, reload_server_crypto};
 pub use huginn_certs::cipher_suites::{is_cipher_suite_supported, supported_cipher_suites};
 pub use huginn_certs::kx_groups::{is_curve_supported, supported_curves};

--- a/huginn-proxy-lib/tests/telemetry/mod.rs
+++ b/huginn-proxy-lib/tests/telemetry/mod.rs
@@ -1,2 +1,3 @@
 mod health_format;
 mod readiness;
+mod tracing;

--- a/huginn-proxy-lib/tests/telemetry/tracing.rs
+++ b/huginn-proxy-lib/tests/telemetry/tracing.rs
@@ -35,7 +35,6 @@ impl<'a> MakeWriter<'a> for CaptureMakeWriter {
     }
 }
 
-/// Emit events under `filter` and return everything the fmt layer actually wrote.
 fn captured_logs(filter: &str, emit: impl FnOnce()) -> String {
     let buffer: Buffer = Arc::new(Mutex::new(Vec::new()));
     let fmt_layer = tracing_subscriber::fmt::layer()
@@ -76,16 +75,13 @@ fn default_filter_drops_huginn_net_tls_events() {
     );
 }
 
-/// `RUST_LOG` replaces the default filter wholesale, so an operator can always opt the
-/// silenced target back in. Without this, the suppression would be unreachable.
+/// `RUST_LOG` unset must fall through to our default filter. If `try_from_default_env`
+/// ever returned `Ok` for a missing variable, the `unwrap_or_else` below it would never
+/// run and `QUIET_TARGETS` would silently stop being applied.
 #[test]
-fn rust_log_can_restore_the_silenced_target() {
-    let logs = captured_logs("info,huginn_net_tls=error", || {
-        tracing::error!(target: "huginn_net_tls", "TLS plaintext parsing failed");
-    });
-
+fn unset_rust_log_falls_through_to_the_default_filter() {
     assert!(
-        logs.contains("TLS plaintext parsing failed"),
-        "operator opt-in via RUST_LOG did not restore the target: {logs}"
+        tracing_subscriber::EnvFilter::try_from_default_env().is_err(),
+        "the default filter is only installed when try_from_default_env fails"
     );
 }

--- a/huginn-proxy-lib/tests/telemetry/tracing.rs
+++ b/huginn-proxy-lib/tests/telemetry/tracing.rs
@@ -1,0 +1,91 @@
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use huginn_proxy_lib::telemetry::default_log_filter;
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+type Buffer = Arc<Mutex<Vec<u8>>>;
+
+struct CaptureWriter(Buffer);
+
+impl io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut guard = match self.0.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct CaptureMakeWriter(Buffer);
+
+impl<'a> MakeWriter<'a> for CaptureMakeWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        CaptureWriter(Arc::clone(&self.0))
+    }
+}
+
+/// Emit events under `filter` and return everything the fmt layer actually wrote.
+fn captured_logs(filter: &str, emit: impl FnOnce()) -> String {
+    let buffer: Buffer = Arc::new(Mutex::new(Vec::new()));
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_ansi(false)
+        .with_target(true)
+        .with_writer(CaptureMakeWriter(Arc::clone(&buffer)));
+    let subscriber = Registry::default()
+        .with(EnvFilter::new(filter))
+        .with(fmt_layer);
+
+    tracing::subscriber::with_default(subscriber, emit);
+
+    let logs = match buffer.lock() {
+        Ok(guard) => String::from_utf8_lossy(&guard).into_owned(),
+        Err(poisoned) => String::from_utf8_lossy(&poisoned.into_inner()).into_owned(),
+    };
+    logs
+}
+
+/// The whole point of the default filter: `huginn-net-tls` logs a JA4 parse `error` for
+/// every non-TLS byte on the TLS port, and none of it should reach the operator's log.
+/// Asserting on behavior rather than on the directive string catches a target name that
+/// parses but never matches (`huginn-net-tls` with hyphens, say).
+#[test]
+fn default_filter_drops_huginn_net_tls_events() {
+    let logs = captured_logs(&default_log_filter("info"), || {
+        tracing::error!(target: "huginn_net_tls", "TLS plaintext parsing failed");
+        tracing::info!(target: "huginn_proxy_lib::proxy", "listener bound");
+    });
+
+    assert!(
+        !logs.contains("TLS plaintext parsing failed"),
+        "huginn-net-tls noise leaked into the log: {logs}"
+    );
+    assert!(
+        logs.contains("listener bound"),
+        "proxy's own events must still be logged: {logs}"
+    );
+}
+
+/// `RUST_LOG` replaces the default filter wholesale, so an operator can always opt the
+/// silenced target back in. Without this, the suppression would be unreachable.
+#[test]
+fn rust_log_can_restore_the_silenced_target() {
+    let logs = captured_logs("info,huginn_net_tls=error", || {
+        tracing::error!(target: "huginn_net_tls", "TLS plaintext parsing failed");
+    });
+
+    assert!(
+        logs.contains("TLS plaintext parsing failed"),
+        "operator opt-in via RUST_LOG did not restore the target: {logs}"
+    );
+}

--- a/huginn-proxy-lib/tests/tls/accept_failure.rs
+++ b/huginn-proxy-lib/tests/tls/accept_failure.rs
@@ -1,4 +1,5 @@
-use huginn_proxy_lib::tls::is_expected_tls_accept_failure;
+use huginn_proxy_lib::telemetry::values;
+use huginn_proxy_lib::tls::TlsAcceptFailure;
 use tokio_rustls::rustls::{Error as RustlsError, InvalidMessage};
 
 fn wrap(tls: RustlsError) -> std::io::Error {
@@ -8,7 +9,10 @@ fn wrap(tls: RustlsError) -> std::io::Error {
 #[test]
 fn handshake_eof_is_expected() {
     let err = std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "tls handshake eof");
-    assert!(is_expected_tls_accept_failure(&err, false));
+    let failure = TlsAcceptFailure::classify(&err, false);
+    assert_eq!(failure, TlsAcceptFailure::PeerEof);
+    assert!(failure.is_expected());
+    assert_eq!(failure.error_type(), values::TLS_ERROR_PEER_EOF);
 }
 
 #[test]
@@ -16,17 +20,40 @@ fn unmatched_sni_is_expected_regardless_of_rustls_error() {
     let err = wrap(RustlsError::AlertReceived(
         tokio_rustls::rustls::AlertDescription::UnrecognisedName,
     ));
-    assert!(is_expected_tls_accept_failure(&err, true));
+    let failure = TlsAcceptFailure::classify(&err, true);
+    assert_eq!(failure, TlsAcceptFailure::UnmatchedSni);
+    assert!(failure.is_expected());
+    assert_eq!(failure.error_type(), values::TLS_ERROR_UNMATCHED_SNI);
 }
 
 #[test]
 fn invalid_content_type_is_expected() {
     let err = wrap(RustlsError::InvalidMessage(InvalidMessage::InvalidContentType));
-    assert!(is_expected_tls_accept_failure(&err, false));
+    let failure = TlsAcceptFailure::classify(&err, false);
+    assert_eq!(failure, TlsAcceptFailure::NotTls);
+    assert!(failure.is_expected());
+    assert_eq!(failure.error_type(), values::TLS_ERROR_NOT_TLS);
 }
 
 #[test]
 fn mtls_missing_client_cert_stays_unexpected() {
     let err = wrap(RustlsError::NoCertificatesPresented);
-    assert!(!is_expected_tls_accept_failure(&err, false));
+    let failure = TlsAcceptFailure::classify(&err, false);
+    assert_eq!(failure, TlsAcceptFailure::Other);
+    assert!(!failure.is_expected());
+    assert_eq!(failure.error_type(), values::TLS_ERROR_OTHER);
+}
+
+#[test]
+fn expected_failures_have_distinct_error_types() {
+    let types = [
+        TlsAcceptFailure::PeerEof.error_type(),
+        TlsAcceptFailure::UnmatchedSni.error_type(),
+        TlsAcceptFailure::NotTls.error_type(),
+        TlsAcceptFailure::Other.error_type(),
+    ];
+    let mut unique = types.to_vec();
+    unique.sort_unstable();
+    unique.dedup();
+    assert_eq!(unique.len(), types.len());
 }

--- a/huginn-proxy-lib/tests/tls/accept_failure.rs
+++ b/huginn-proxy-lib/tests/tls/accept_failure.rs
@@ -1,0 +1,32 @@
+use huginn_proxy_lib::tls::is_expected_tls_accept_failure;
+use tokio_rustls::rustls::{Error as RustlsError, InvalidMessage};
+
+fn wrap(tls: RustlsError) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, tls)
+}
+
+#[test]
+fn handshake_eof_is_expected() {
+    let err = std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "tls handshake eof");
+    assert!(is_expected_tls_accept_failure(&err, false));
+}
+
+#[test]
+fn unmatched_sni_is_expected_regardless_of_rustls_error() {
+    let err = wrap(RustlsError::AlertReceived(
+        tokio_rustls::rustls::AlertDescription::UnrecognisedName,
+    ));
+    assert!(is_expected_tls_accept_failure(&err, true));
+}
+
+#[test]
+fn invalid_content_type_is_expected() {
+    let err = wrap(RustlsError::InvalidMessage(InvalidMessage::InvalidContentType));
+    assert!(is_expected_tls_accept_failure(&err, false));
+}
+
+#[test]
+fn mtls_missing_client_cert_stays_unexpected() {
+    let err = wrap(RustlsError::NoCertificatesPresented);
+    assert!(!is_expected_tls_accept_failure(&err, false));
+}

--- a/huginn-proxy-lib/tests/tls/accept_failure.rs
+++ b/huginn-proxy-lib/tests/tls/accept_failure.rs
@@ -1,5 +1,5 @@
 use huginn_proxy_lib::telemetry::values;
-use huginn_proxy_lib::tls::TlsAcceptFailure;
+use huginn_proxy_lib::tls::{FailureSeverity, TlsAcceptFailure};
 use tokio_rustls::rustls::{Error as RustlsError, InvalidMessage};
 
 fn wrap(tls: RustlsError) -> std::io::Error {
@@ -15,6 +15,33 @@ fn handshake_eof_is_expected() {
     assert_eq!(failure.error_type(), values::TLS_ERROR_PEER_EOF);
 }
 
+/// Connect-then-reset is what most scanners and some load-balancer health checks do, and
+/// it reaches us as a raw socket error while reading the ClientHello, before rustls sees
+/// anything. It has to be classified as peer noise or it keeps the log at `warn`.
+#[test]
+fn peer_reset_is_expected() {
+    for kind in [
+        std::io::ErrorKind::ConnectionReset,
+        std::io::ErrorKind::ConnectionAborted,
+        std::io::ErrorKind::BrokenPipe,
+    ] {
+        let err = std::io::Error::new(kind, "peer went away");
+        let failure = TlsAcceptFailure::classify(&err, false);
+        assert_eq!(failure, TlsAcceptFailure::PeerEof, "{kind:?}");
+        assert!(failure.is_expected(), "{kind:?}");
+        assert_eq!(failure.error_type(), values::TLS_ERROR_PEER_EOF, "{kind:?}");
+    }
+}
+
+/// A read fault that is not the peer disconnecting is a real proxy-side problem.
+#[test]
+fn other_io_errors_stay_unexpected() {
+    let err = std::io::Error::new(std::io::ErrorKind::OutOfMemory, "no buffers");
+    let failure = TlsAcceptFailure::classify(&err, false);
+    assert_eq!(failure, TlsAcceptFailure::Other);
+    assert!(!failure.is_expected());
+}
+
 #[test]
 fn unmatched_sni_is_expected_regardless_of_rustls_error() {
     let err = wrap(RustlsError::AlertReceived(
@@ -24,6 +51,36 @@ fn unmatched_sni_is_expected_regardless_of_rustls_error() {
     assert_eq!(failure, TlsAcceptFailure::UnmatchedSni);
     assert!(failure.is_expected());
     assert_eq!(failure.error_type(), values::TLS_ERROR_UNMATCHED_SNI);
+}
+
+/// An unmatched SNI is usually a domain missing from the config, so unlike the rest of
+/// the routine noise it stays visible at the default log level. Same call as rpxy makes.
+#[test]
+fn unmatched_sni_stays_visible_at_info() {
+    let err = wrap(RustlsError::AlertReceived(
+        tokio_rustls::rustls::AlertDescription::UnrecognisedName,
+    ));
+    let failure = TlsAcceptFailure::classify(&err, true);
+    assert_eq!(failure.severity(), FailureSeverity::Info);
+}
+
+/// Peer noise must not reach the default log level, and a real fault must.
+#[test]
+fn severity_splits_noise_from_faults() {
+    let cases = [
+        (TlsAcceptFailure::PeerEof, FailureSeverity::Debug),
+        (TlsAcceptFailure::NotTls, FailureSeverity::Debug),
+        (TlsAcceptFailure::UnmatchedSni, FailureSeverity::Info),
+        (TlsAcceptFailure::Other, FailureSeverity::Warn),
+    ];
+    for (failure, expected) in cases {
+        assert_eq!(failure.severity(), expected, "{failure:?}");
+        assert_eq!(
+            failure.is_expected(),
+            expected != FailureSeverity::Warn,
+            "is_expected must track severity for {failure:?}"
+        );
+    }
 }
 
 #[test]

--- a/huginn-proxy-lib/tests/tls/accept_failure.rs
+++ b/huginn-proxy-lib/tests/tls/accept_failure.rs
@@ -54,7 +54,7 @@ fn unmatched_sni_is_expected_regardless_of_rustls_error() {
 }
 
 /// An unmatched SNI is usually a domain missing from the config, so unlike the rest of
-/// the routine noise it stays visible at the default log level. Same call as rpxy makes.
+/// the routine noise it stays visible at the default log level.
 #[test]
 fn unmatched_sni_stays_visible_at_info() {
     let err = wrap(RustlsError::AlertReceived(

--- a/huginn-proxy-lib/tests/tls/mod.rs
+++ b/huginn-proxy-lib/tests/tls/mod.rs
@@ -1,3 +1,4 @@
+mod accept_failure;
 mod cert_source;
 mod options;
 mod session_resumption;


### PR DESCRIPTION
## Summary
- Expected TLS accept failures (peer abort, unmatched SNI, non-TLS bytes) now log at `debug` instead of `warn`. Handshake timeouts and cert/mTLS failures stay at `warn`.
- `huginn_tls_handshake_errors_total` now emits `error_type` (`client_hello_read`, `peer_eof`, `unmatched_sni`, `not_tls`, `handshake_timeout`, `other`) so demoted causes stay diagnosable in metrics, a missing domain shows up as `unmatched_sni`.
- `huginn-net-tls` (JA4 parse `ERROR` on garbage/HTTP on the TLS port) is off in the default `EnvFilter`. `RUST_LOG` replaces the filter wholesale, so `RUST_LOG=info,huginn_net_tls=debug` restores those events.
